### PR TITLE
fix(cli): harden gavel report and dogfood it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
   # ran `gavel judge`.
   dogfood:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     # Building every analyzer aspect from a cold Bazel cache takes ~18 min; warm
     # runs are far quicker. Kept above the 10-min cap of the other jobs so a cold
     # cache does not spuriously fail the gate.
@@ -100,6 +103,13 @@ jobs:
 
       - name: Judge (gavel gates itself)
         run: bazel-bin/apps/cli/cmd/gavel/gavel_/gavel judge
+
+      - name: Report the verdict to the PR
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bazel-bin/apps/cli/cmd/gavel/gavel_/gavel report --commit "$HEAD_SHA"
 
   # Guards generated artifacts against drift from their source of truth:
   # OpenAPI (Go DTOs + TS client) and the clispec (CLI flags.gen.go).

--- a/core/userinterface/cli/judge/judge.go
+++ b/core/userinterface/cli/judge/judge.go
@@ -168,7 +168,7 @@ func run(cmd *cobra.Command, opts Options, deps deps) error {
 		return err
 	}
 	if err := outputjson.WriteCache(workspace, results); err != nil {
-		deps.log.Warn("failed to write results cache", "error", err)
+		return fmt.Errorf("write results cache: %w", err)
 	}
 	if err := emitSARIF(writer, results, opts); err != nil {
 		return err

--- a/core/userinterface/cli/judge/output/json/load.go
+++ b/core/userinterface/cli/judge/output/json/load.go
@@ -14,19 +14,14 @@ const (
 	verdictFile = "verdict.json"
 )
 
-// ErrNoResults signals that no judge results were found under the workspace:
-// `gavel judge` has not run, so there is nothing for a consumer to deliver.
 var ErrNoResults = errors.New("no judge results found under .gavel/results; run `gavel judge` first")
 
-// Verdict is the read view of a cached judge result. Its fields are mapped from
-// the write-side projectDTO, which owns the on-disk JSON contract (the json
-// tags) — so a single tagged struct set defines the format and the read and
-// write sides cannot drift.
 type Verdict struct {
 	Name            string
 	Verdict         string
 	CommitSHA       string
 	Branch          string
+	StartedAt       string
 	CoveragePercent *float64
 	Findings        []VerdictFinding
 	Violations      []VerdictViolation
@@ -59,20 +54,18 @@ type VerdictDelta struct {
 	ExistingCount int
 }
 
-// Load reads every .gavel/results/<project>/verdict.json cached by WriteCache
-// under the workspace. It returns ErrNoResults when the results directory is
-// absent or holds no verdict files.
-func Load(workspace string) ([]Verdict, error) {
+func Load(workspace string) ([]Verdict, []string, error) {
 	dir := filepath.Join(workspace, gavelDir, resultsDir)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, ErrNoResults
+			return nil, nil, ErrNoResults
 		}
-		return nil, fmt.Errorf("read results dir: %w", err)
+		return nil, nil, fmt.Errorf("read results dir: %w", err)
 	}
 
 	var verdicts []Verdict
+	var skipped []string
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -83,19 +76,20 @@ func Load(workspace string) ([]Verdict, error) {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return nil, fmt.Errorf("read %s: %w", path, err)
+			return nil, nil, fmt.Errorf("read %s: %w", path, err)
 		}
 		var dto projectDTO
 		if err := encjson.Unmarshal(data, &dto); err != nil {
-			return nil, fmt.Errorf("parse %s: %w", path, err)
+			skipped = append(skipped, path)
+			continue
 		}
 		verdicts = append(verdicts, toVerdict(dto))
 	}
 
 	if len(verdicts) == 0 {
-		return nil, ErrNoResults
+		return nil, skipped, ErrNoResults
 	}
-	return verdicts, nil
+	return verdicts, skipped, nil
 }
 
 func toVerdict(dto projectDTO) Verdict {
@@ -104,11 +98,9 @@ func toVerdict(dto projectDTO) Verdict {
 		Verdict:         dto.Verdict,
 		CommitSHA:       dto.CommitSHA,
 		Branch:          dto.Branch,
+		StartedAt:       dto.StartedAt,
 		CoveragePercent: dto.CoveragePercent,
 	}
-	// Direct struct conversions (fields are identical): this also guards the
-	// contract — if a write-side DTO field changes, the conversion stops
-	// compiling, forcing the read view to be updated rather than drifting.
 	for _, finding := range dto.Findings {
 		verdict.Findings = append(verdict.Findings, VerdictFinding(finding))
 	}

--- a/core/userinterface/cli/judge/output/json/load_test.go
+++ b/core/userinterface/cli/judge/output/json/load_test.go
@@ -39,7 +39,7 @@ func TestLoadReadsVerdictsWrittenByWriteCache(t *testing.T) {
 	}
 	require.NoError(t, outputjson.WriteCache(workspace, []pipeline.Result{result}))
 
-	verdicts, err := outputjson.Load(workspace)
+	verdicts, _, err := outputjson.Load(workspace)
 	require.NoError(t, err)
 	require.Len(t, verdicts, 1)
 
@@ -81,7 +81,7 @@ func TestLoadParsesExistingStatusAndAbsentCoverage(t *testing.T) {
       "delta": {"has_previous": true, "new_count": 0, "fixed_count": 2, "existing_count": 1}
     }`)
 
-	verdicts, err := outputjson.Load(workspace)
+	verdicts, _, err := outputjson.Load(workspace)
 	require.NoError(t, err)
 	require.Len(t, verdicts, 1)
 
@@ -96,8 +96,30 @@ func TestLoadParsesExistingStatusAndAbsentCoverage(t *testing.T) {
 }
 
 func TestLoadReturnsErrNoResultsWhenDirAbsent(t *testing.T) {
-	_, err := outputjson.Load(t.TempDir())
+	_, _, err := outputjson.Load(t.TempDir())
 	assert.ErrorIs(t, err, outputjson.ErrNoResults)
+}
+
+func TestLoadSkipsUnparseableFilesAndReportsThem(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdictFixture(t, workspace, "core", `{"name":"core","verdict":"pass"}`)
+	writeVerdictFixture(t, workspace, "web", `{ not json`)
+
+	verdicts, skipped, err := outputjson.Load(workspace)
+	require.NoError(t, err)
+	require.Len(t, verdicts, 1)
+	assert.Equal(t, "core", verdicts[0].Name)
+	require.Len(t, skipped, 1)
+	assert.Contains(t, skipped[0], "web")
+}
+
+func TestLoadReturnsErrNoResultsWhenEveryFileCorrupt(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdictFixture(t, workspace, "web", `{ not json`)
+
+	_, skipped, err := outputjson.Load(workspace)
+	assert.ErrorIs(t, err, outputjson.ErrNoResults)
+	assert.Len(t, skipped, 1)
 }
 
 func writeVerdictFixture(t *testing.T, workspace, project, body string) {

--- a/core/userinterface/cli/judge/output/json/load_test.go
+++ b/core/userinterface/cli/judge/output/json/load_test.go
@@ -122,6 +122,53 @@ func TestLoadReturnsErrNoResultsWhenEveryFileCorrupt(t *testing.T) {
 	assert.Len(t, skipped, 1)
 }
 
+func TestLoadSkipsNonDirectoryEntriesAndEmptyProjects(t *testing.T) {
+	workspace := t.TempDir()
+	results := filepath.Join(workspace, ".gavel", "results")
+	require.NoError(t, os.MkdirAll(filepath.Join(results, "empty"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(results, "stray.txt"), []byte("x"), 0o644))
+	writeVerdictFixture(t, workspace, "core", `{"name":"core","verdict":"pass"}`)
+
+	verdicts, skipped, err := outputjson.Load(workspace)
+	require.NoError(t, err)
+	require.Len(t, verdicts, 1)
+	assert.Equal(t, "core", verdicts[0].Name)
+	assert.Empty(t, skipped)
+}
+
+func TestLoadMapsViolations(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdictFixture(t, workspace, "core", `{"name":"core","verdict":"fail","commit_sha":"c1",
+		"violations":[{"rule":"deny","source_pkg":"a","target_pkg":"b","message":"forbidden","status":"new"}]}`)
+
+	verdicts, _, err := outputjson.Load(workspace)
+	require.NoError(t, err)
+	require.Len(t, verdicts, 1)
+	require.Len(t, verdicts[0].Violations, 1)
+	assert.Equal(t, "deny", verdicts[0].Violations[0].Rule)
+	assert.Equal(t, "forbidden", verdicts[0].Violations[0].Message)
+}
+
+func TestLoadErrorsWhenResultsPathIsNotADirectory(t *testing.T) {
+	workspace := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(workspace, ".gavel"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".gavel", "results"), []byte("x"), 0o644))
+
+	_, _, err := outputjson.Load(workspace)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, outputjson.ErrNoResults)
+}
+
+func TestLoadErrorsWhenVerdictFileCannotBeRead(t *testing.T) {
+	workspace := t.TempDir()
+	dir := filepath.Join(workspace, ".gavel", "results", "core")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "verdict.json"), 0o755))
+
+	_, _, err := outputjson.Load(workspace)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, outputjson.ErrNoResults)
+}
+
 func writeVerdictFixture(t *testing.T, workspace, project, body string) {
 	t.Helper()
 	dir := filepath.Join(workspace, ".gavel", "results", project)

--- a/core/userinterface/cli/report/checks/build.go
+++ b/core/userinterface/cli/report/checks/build.go
@@ -1,7 +1,3 @@
-// Package checks turns judged verdicts into a GitHub Checks payload: a check
-// run conclusion, a markdown summary, and inline diff annotations. It is pure —
-// no network, no GitHub client — so the mapping can be tested in isolation and
-// the HTTP adapter only has to deliver what this package produces.
 package checks
 
 import (
@@ -11,17 +7,13 @@ import (
 	outputjson "github.com/usegavel/gavel/core/userinterface/cli/judge/output/json"
 )
 
-// MaxAnnotationsPerRequest is GitHub's cap on annotations accepted in a single
-// check-run create or update call.
 const MaxAnnotationsPerRequest = 50
 
-// GitHub check-run conclusions this package emits.
 const (
 	ConclusionSuccess = "success"
 	ConclusionFailure = "failure"
 )
 
-// Level is a GitHub annotation level.
 type Level string
 
 const (
@@ -39,7 +31,6 @@ const (
 	minGitHubLine    = 1
 )
 
-// Annotation is one inline finding placed on the pull-request diff.
 type Annotation struct {
 	Path      string
 	StartLine int
@@ -49,8 +40,6 @@ type Annotation struct {
 	Message   string
 }
 
-// CheckRun is the sink-agnostic representation of a GitHub check run. The HTTP
-// adapter maps it to the Checks API wire format.
 type CheckRun struct {
 	Name        string
 	HeadSHA     string
@@ -60,14 +49,12 @@ type CheckRun struct {
 	Annotations []Annotation
 }
 
-// Options tunes how a CheckRun is built from verdicts.
 type Options struct {
 	CheckName string
 	HeadSHA   string
 	NewOnly   bool
 }
 
-// Build assembles a CheckRun from the judged verdicts.
 func Build(verdicts []outputjson.Verdict, opts Options) CheckRun {
 	return CheckRun{
 		Name:        checkName(opts.CheckName),
@@ -79,8 +66,6 @@ func Build(verdicts []outputjson.Verdict, opts Options) CheckRun {
 	}
 }
 
-// BatchAnnotations splits annotations into chunks no larger than maxPerBatch,
-// matching GitHub's per-request annotation cap. Empty input yields no batches.
 func BatchAnnotations(annotations []Annotation, maxPerBatch int) [][]Annotation {
 	if len(annotations) == 0 || maxPerBatch <= 0 {
 		return nil
@@ -114,9 +99,6 @@ func headSHA(override string, verdicts []outputjson.Verdict) string {
 }
 
 func conclusion(verdicts []outputjson.Verdict) string {
-	// Fail-safe: a check is success only if every project explicitly passed.
-	// Any other value — "fail", an empty string, or a future/unknown verdict —
-	// blocks the merge rather than silently going green.
 	for _, verdict := range verdicts {
 		if verdict.Verdict != verdictPass {
 			return ConclusionFailure

--- a/core/userinterface/cli/report/github/publisher.go
+++ b/core/userinterface/cli/report/github/publisher.go
@@ -1,7 +1,3 @@
-// Package github publishes a Gavel check run to the GitHub Checks API. It is a
-// CLI outbound HTTP client, so it lives in the userinterface layer alongside the
-// report command — mirroring the server-mode api client — not in infrastructure,
-// which may not import userinterface types such as checks.CheckRun.
 package github
 
 import (
@@ -33,14 +29,12 @@ var (
 	errInvalidRepo = errors.New("github: repo must be in owner/name form")
 )
 
-// Config holds the credentials and target for publishing a check run.
 type Config struct {
 	Token   string
 	Repo    string
 	BaseURL string
 }
 
-// Publisher delivers a CheckRun to the GitHub Checks API.
 type Publisher struct {
 	client  *http.Client
 	token   string
@@ -49,13 +43,11 @@ type Publisher struct {
 	baseURL string
 }
 
-// Result identifies the created check run.
 type Result struct {
 	CheckRunID int64
 	URL        string
 }
 
-// NewPublisher validates the config and builds a Publisher.
 func NewPublisher(config Config) (*Publisher, error) {
 	if config.Token == "" {
 		return nil, errEmptyToken
@@ -77,8 +69,6 @@ func NewPublisher(config Config) (*Publisher, error) {
 	}, nil
 }
 
-// Publish creates the check run with the first batch of annotations, then adds
-// any remaining batches via update calls (GitHub caps annotations per request).
 func (p *Publisher) Publish(ctx context.Context, checkRun checks.CheckRun) (Result, error) {
 	batches := checks.BatchAnnotations(checkRun.Annotations, checks.MaxAnnotationsPerRequest)
 

--- a/core/userinterface/cli/report/github/publisher_test.go
+++ b/core/userinterface/cli/report/github/publisher_test.go
@@ -121,7 +121,7 @@ func TestPublishReturnsErrorOnMalformedResponse(t *testing.T) {
 func TestPublishReturnsErrorWhenServerUnreachable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	unreachable := server.URL
-	server.Close() // close now so the address refuses the connection
+	server.Close()
 
 	publisher, err := github.NewPublisher(github.Config{Token: "secret", Repo: "octo/repo", BaseURL: unreachable})
 	require.NoError(t, err)

--- a/core/userinterface/cli/report/report.go
+++ b/core/userinterface/cli/report/report.go
@@ -15,19 +15,14 @@ import (
 
 const sinkGitHubChecks = "github-checks"
 
-// WorkspaceResolver locates the workspace root that holds .gavel/results.
 type WorkspaceResolver func() (string, error)
 
-// ChecksPublisher delivers a built check run to an external sink.
 type ChecksPublisher interface {
 	Publish(ctx context.Context, checkRun checks.CheckRun) (github.Result, error)
 }
 
-// PublisherFactory builds a ChecksPublisher from resolved credentials and target.
 type PublisherFactory func(config github.Config) (ChecksPublisher, error)
 
-// NewCommand builds the `gavel report` command. It reads the verdict cached by
-// `gavel judge` and delivers it to an external sink (GitHub Checks).
 func NewCommand(resolveWorkspace WorkspaceResolver, newPublisher PublisherFactory) *cobra.Command {
 	opts := Options{}
 	cmd := &cobra.Command{
@@ -55,17 +50,27 @@ func run(ctx context.Context, writer io.Writer, opts Options, resolveWorkspace W
 		return fmt.Errorf("unsupported sink %q (only %q is supported)", opts.To, sinkGitHubChecks)
 	}
 
+	publisher, err := newPublisher(github.Config{Token: opts.GithubToken, Repo: opts.Repo})
+	if err != nil {
+		return err
+	}
+
 	workspace, err := resolveWorkspace()
 	if err != nil {
 		return err
 	}
 
-	verdicts, err := outputjson.Load(workspace)
+	verdicts, skipped, err := outputjson.Load(workspace)
 	if errors.Is(err, outputjson.ErrNoResults) {
 		return errors.New("nothing to report: run `gavel judge` first")
 	}
 	if err != nil {
 		return err
+	}
+	for _, path := range skipped {
+		if _, err := fmt.Fprintf(writer, "warning: skipped unparseable %s\n", path); err != nil {
+			return err
+		}
 	}
 
 	if opts.Project != "" {
@@ -73,6 +78,8 @@ func run(ctx context.Context, writer io.Writer, opts Options, resolveWorkspace W
 		if len(verdicts) == 0 {
 			return fmt.Errorf("no cached verdict for project %q", opts.Project)
 		}
+	} else {
+		verdicts = latestRun(verdicts)
 	}
 
 	checkRun := checks.Build(verdicts, checks.Options{
@@ -83,11 +90,6 @@ func run(ctx context.Context, writer io.Writer, opts Options, resolveWorkspace W
 	if checkRun.HeadSHA == "" {
 		return errors.New("no commit SHA to attach the check run to: pass --commit, " +
 			"or run `gavel judge` where it can detect the commit")
-	}
-
-	publisher, err := newPublisher(github.Config{Token: opts.GithubToken, Repo: opts.Repo})
-	if err != nil {
-		return err
 	}
 
 	result, err := publisher.Publish(ctx, checkRun)
@@ -102,15 +104,28 @@ func run(ctx context.Context, writer io.Writer, opts Options, resolveWorkspace W
 	return nil
 }
 
-// NewGitHubPublisher is the default PublisherFactory: it builds a GitHub Checks
-// publisher from the resolved config. The explicit nil return on error avoids
-// handing back a non-nil interface wrapping a nil *github.Publisher.
 func NewGitHubPublisher(config github.Config) (ChecksPublisher, error) {
 	publisher, err := github.NewPublisher(config)
 	if err != nil {
 		return nil, err
 	}
 	return publisher, nil
+}
+
+func latestRun(verdicts []outputjson.Verdict) []outputjson.Verdict {
+	latest := ""
+	for _, verdict := range verdicts {
+		if verdict.StartedAt > latest {
+			latest = verdict.StartedAt
+		}
+	}
+	filtered := make([]outputjson.Verdict, 0, len(verdicts))
+	for _, verdict := range verdicts {
+		if verdict.StartedAt == latest {
+			filtered = append(filtered, verdict)
+		}
+	}
+	return filtered
 }
 
 func filterByProject(verdicts []outputjson.Verdict, project string) []outputjson.Verdict {

--- a/core/userinterface/cli/report/report_test.go
+++ b/core/userinterface/cli/report/report_test.go
@@ -27,6 +27,12 @@ func (fake *fakePublisher) Publish(_ context.Context, checkRun checks.CheckRun) 
 	return fake.result, fake.err
 }
 
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
 func runReport(workspace string, publisher report.ChecksPublisher, arguments ...string) (string, error) {
 	command := report.NewCommand(
 		func() (string, error) { return workspace, nil },
@@ -120,6 +126,41 @@ func TestReportWarnsAboutSkippedFiles(t *testing.T) {
 	assert.Contains(t, output, "web")
 }
 
+func TestReportPropagatesWarningWriteError(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdict(t, workspace, "core", `{"name":"core","verdict":"pass","commit_sha":"c1"}`)
+	writeVerdict(t, workspace, "web", `{ not json`)
+
+	command := report.NewCommand(
+		func() (string, error) { return workspace, nil },
+		func(github.Config) (report.ChecksPublisher, error) {
+			return &fakePublisher{result: github.Result{URL: "u"}}, nil
+		},
+	)
+	command.SetOut(failingWriter{})
+	command.SetErr(failingWriter{})
+	command.SetArgs([]string{"--repo=o/r", "--github-token=tok"})
+
+	require.Error(t, command.Execute())
+}
+
+func TestReportPropagatesFinalWriteError(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdict(t, workspace, "core", `{"name":"core","verdict":"pass","commit_sha":"c1"}`)
+
+	command := report.NewCommand(
+		func() (string, error) { return workspace, nil },
+		func(github.Config) (report.ChecksPublisher, error) {
+			return &fakePublisher{result: github.Result{URL: "u"}}, nil
+		},
+	)
+	command.SetOut(failingWriter{})
+	command.SetErr(failingWriter{})
+	command.SetArgs([]string{"--repo=o/r", "--github-token=tok"})
+
+	require.Error(t, command.Execute())
+}
+
 func TestReportValidatesPublisherBeforeTouchingWorkspace(t *testing.T) {
 	command := report.NewCommand(
 		func() (string, error) {
@@ -137,6 +178,47 @@ func TestReportValidatesPublisherBeforeTouchingWorkspace(t *testing.T) {
 	err := command.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bad config")
+}
+
+func TestReportErrorsWhenProjectHasNoVerdict(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdict(t, workspace, "core", `{"name":"core","verdict":"pass","commit_sha":"c1"}`)
+
+	_, err := runReport(workspace, &fakePublisher{}, "--project=ghost", "--repo=o/r", "--github-token=tok")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+}
+
+func TestReportPropagatesWorkspaceError(t *testing.T) {
+	command := report.NewCommand(
+		func() (string, error) { return "", errors.New("no workspace") },
+		func(github.Config) (report.ChecksPublisher, error) { return &fakePublisher{}, nil },
+	)
+	command.SetOut(&bytes.Buffer{})
+	command.SetArgs([]string{"--repo=o/r", "--github-token=tok"})
+
+	err := command.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no workspace")
+}
+
+func TestReportPropagatesPublishError(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdict(t, workspace, "core", `{"name":"core","verdict":"pass","commit_sha":"c1"}`)
+	publisher := &fakePublisher{err: errors.New("api down")}
+
+	_, err := runReport(workspace, publisher, "--repo=o/r", "--github-token=tok")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api down")
+}
+
+func TestReportPropagatesLoadError(t *testing.T) {
+	workspace := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(workspace, ".gavel"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".gavel", "results"), []byte("x"), 0o644))
+
+	_, err := runReport(workspace, &fakePublisher{}, "--repo=o/r", "--github-token=tok")
+	require.Error(t, err)
 }
 
 func TestReportErrorsWithoutCache(t *testing.T) {

--- a/core/userinterface/cli/report/report_test.go
+++ b/core/userinterface/cli/report/report_test.go
@@ -3,6 +3,7 @@ package report_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -92,6 +93,50 @@ func TestReportErrorsWhenCommitSHAMissing(t *testing.T) {
 	_, err := runReport(workspace, &fakePublisher{}, "--repo=o/r", "--github-token=tok")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "commit")
+}
+
+func TestReportReportsOnlyTheLatestRun(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdict(t, workspace, "core", `{"name":"core","verdict":"fail","commit_sha":"c1","started_at":"2026-07-04T10:00:00Z"}`)
+	writeVerdict(t, workspace, "cli", `{"name":"cli","verdict":"pass","commit_sha":"c2","started_at":"2026-07-04T11:00:00Z"}`)
+	publisher := &fakePublisher{result: github.Result{URL: "u"}}
+
+	_, err := runReport(workspace, publisher, "--repo=o/r", "--github-token=tok")
+	require.NoError(t, err)
+	assert.Equal(t, checks.ConclusionSuccess, publisher.received.Conclusion,
+		"the stale failing core verdict from an earlier run must be dropped")
+	assert.Equal(t, "c2", publisher.received.HeadSHA)
+}
+
+func TestReportWarnsAboutSkippedFiles(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdict(t, workspace, "core", `{"name":"core","verdict":"pass","commit_sha":"c1"}`)
+	writeVerdict(t, workspace, "web", `{ not json`)
+	publisher := &fakePublisher{result: github.Result{URL: "u"}}
+
+	output, err := runReport(workspace, publisher, "--repo=o/r", "--github-token=tok")
+	require.NoError(t, err)
+	assert.Contains(t, output, "warning")
+	assert.Contains(t, output, "web")
+}
+
+func TestReportValidatesPublisherBeforeTouchingWorkspace(t *testing.T) {
+	command := report.NewCommand(
+		func() (string, error) {
+			t.Fatal("workspace resolved before the publisher was validated")
+			return "", nil
+		},
+		func(github.Config) (report.ChecksPublisher, error) {
+			return nil, errors.New("bad config")
+		},
+	)
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"--repo=o/r", "--github-token=t"})
+
+	err := command.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad config")
 }
 
 func TestReportErrorsWithoutCache(t *testing.T) {


### PR DESCRIPTION
## What
Hardens `gavel report` with the four deferred code-review findings (roadmap #1),
and wires it into gavel's own CI so gavel dogfoods the feature on its own PRs.

## Why
The report feature shipped with a solid happy path, but a high-effort review
found four robustness gaps; and gavel judged itself in CI without yet decorating
its own PRs. This closes both.

## How
- **Report only the latest judge run** — filter verdicts by the shared
  `StartedAt` stamp, so a scoped `gavel judge --project=X` no longer leaves
  stale verdicts for `report` to publish. `--project` stays an explicit override.
- **Skip-and-warn on a corrupt `verdict.json`** instead of aborting every
  project; `Load` returns the skipped paths and `report` warns.
- **Fail judge when it can't write the cache**, instead of exiting 0 and leaving
  `report` to say "run judge first" after a run that looked fine.
- **Validate `--repo`/`--github-token` up front**, before loading and building.
- **CI**: the dogfood job gains `checks: write` and a `report` step
  (`if: always()`, PR head SHA via env, skips fork PRs whose token is read-only).
- Dropped the explanatory code comments from the report feature (zero-comment
  convention); the rationale lives in `docs/design/github-checks-reporting.md`.

## Testing
- New unit tests per finding; 16 package tests green.
- `gavel judge --project=core` PASS — 94.6%, 0 findings.
- This same-repo PR should exercise the new dogfood `report` step — gavel
  decorating its own pull request.

## Risk & scope
- Deferred (tracked in the internal backlog): non-atomic >50-annotation publish
  — GitHub can't delete check runs, so a proper fix needs retry / truncation
  marking. Lowest-probability finding.
- `report --project=X` intentionally bypasses the latest-run filter.
- No API or behaviour changes beyond report/judge.
