### PR TITLE
feat(cli): report posts a sticky PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      pull-requests: write
     # Building every analyzer aspect from a cold Bazel cache takes ~18 min; warm
     # runs are far quicker. Kept above the 10-min cap of the other jobs so a cold
     # cache does not spuriously fail the gate.
@@ -109,7 +110,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: bazel-bin/apps/cli/cmd/gavel/gavel_/gavel report --commit "$HEAD_SHA"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: bazel-bin/apps/cli/cmd/gavel/gavel_/gavel report --commit "$HEAD_SHA" --pr "$PR_NUMBER"
 
   # Guards generated artifacts against drift from their source of truth:
   # OpenAPI (Go DTOs + TS client) and the clispec (CLI flags.gen.go).

--- a/clispec/v1/clispec.yaml
+++ b/clispec/v1/clispec.yaml
@@ -337,6 +337,11 @@ commands:
         type: string
         description: >
           Report only the named project. Reports every cached project if unset.
+      pr:
+        type: int
+        description: >
+          Pull request number. When set, report also posts or updates a sticky
+          summary comment on the PR, alongside the check run.
 
     exit_codes:
       0: Verdict delivered to the sink

--- a/core/userinterface/cli/report/flags.gen.go
+++ b/core/userinterface/cli/report/flags.gen.go
@@ -13,6 +13,7 @@ type Options struct {
 	Commit string
 	GithubToken string
 	NewOnly bool
+	PR int
 	Project string
 	Repo string
 	To string
@@ -24,6 +25,7 @@ func RegisterFlags(cmd *cobra.Command, opts *Options) {
 	cmd.Flags().StringVar(&opts.Commit, "commit", "", "Head commit SHA the check run attaches to. Defaults to the commit recorded in the cached verdict; pass explicitly to override — e.g. the pull-request head SHA, since GITHUB_SHA on a pull_request event is the merge commit and GitHub renders annotations only on the head.")
 	cmd.Flags().StringVar(&opts.GithubToken, "github-token", envOrDefault("GITHUB_TOKEN", ""), "GitHub token with the checks:write permission. Defaults to the Actions GITHUB_TOKEN.")
 	cmd.Flags().BoolVar(&opts.NewOnly, "new-only", true, "Annotate only findings new versus the baseline. Disable to annotate all findings.")
+	cmd.Flags().IntVar(&opts.PR, "pr", 0, "Pull request number. When set, report also posts or updates a sticky summary comment on the PR, alongside the check run.")
 	cmd.Flags().StringVar(&opts.Project, "project", "", "Report only the named project. Reports every cached project if unset.")
 	cmd.Flags().StringVar(&opts.Repo, "repo", envOrDefault("GITHUB_REPOSITORY", ""), "Target repository in owner/repo form. Defaults to GITHUB_REPOSITORY.")
 	cmd.Flags().StringVar(&opts.To, "to", "github-checks", "Delivery sink for the verdict.")

--- a/core/userinterface/cli/report/github/publisher.go
+++ b/core/userinterface/cli/report/github/publisher.go
@@ -49,7 +49,13 @@ type Result struct {
 	URL        string
 }
 
-func NewPublisher(config Config) (*Publisher, error) {
+type Option func(*Publisher)
+
+func WithClient(client *http.Client) Option {
+	return func(publisher *Publisher) { publisher.client = client }
+}
+
+func NewPublisher(config Config, options ...Option) (*Publisher, error) {
 	if config.Token == "" {
 		return nil, errEmptyToken
 	}
@@ -61,13 +67,17 @@ func NewPublisher(config Config) (*Publisher, error) {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
-	return &Publisher{
+	publisher := &Publisher{
 		client:  &http.Client{Timeout: requestTimeout},
 		token:   config.Token,
 		owner:   segments[0],
 		repo:    segments[1],
 		baseURL: strings.TrimRight(baseURL, "/"),
-	}, nil
+	}
+	for _, option := range options {
+		option(publisher)
+	}
+	return publisher, nil
 }
 
 func (p *Publisher) Publish(ctx context.Context, checkRun checks.CheckRun) (Result, error) {

--- a/core/userinterface/cli/report/github/publisher.go
+++ b/core/userinterface/cli/report/github/publisher.go
@@ -22,6 +22,7 @@ const (
 	acceptContentType = "application/vnd.github+json"
 	jsonContentType   = "application/json"
 	requestTimeout    = 30 * time.Second
+	commentMarker     = "<!-- gavel-report -->"
 )
 
 var (
@@ -121,39 +122,86 @@ func (p *Publisher) update(ctx context.Context, checkRunID int64, checkRun check
 }
 
 func (p *Publisher) send(ctx context.Context, method, endpoint string, payload any) (checkRunResponse, error) {
-	encoded, err := json.Marshal(payload)
+	bodyBytes, err := p.request(ctx, method, endpoint, payload)
 	if err != nil {
-		return checkRunResponse{}, fmt.Errorf("marshal payload: %w", err)
+		return checkRunResponse{}, err
 	}
-	request, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(encoded))
-	if err != nil {
-		return checkRunResponse{}, fmt.Errorf("build request: %w", err)
-	}
-	request.Header.Set("Authorization", "Bearer "+p.token)
-	request.Header.Set("Accept", acceptContentType)
-	request.Header.Set("X-GitHub-Api-Version", apiVersion)
-	request.Header.Set("Content-Type", jsonContentType)
-
-	response, err := p.client.Do(request)
-	if err != nil {
-		return checkRunResponse{}, fmt.Errorf("call github: %w", err)
-	}
-	defer func() { _ = response.Body.Close() }()
-
-	bodyBytes, err := io.ReadAll(response.Body)
-	if err != nil {
-		return checkRunResponse{}, fmt.Errorf("read response: %w", err)
-	}
-	if !isSuccessStatus(response.StatusCode) {
-		return checkRunResponse{}, fmt.Errorf("github %s %s: status %d: %s",
-			method, endpoint, response.StatusCode, strings.TrimSpace(string(bodyBytes)))
-	}
-
 	var decoded checkRunResponse
 	if err := json.Unmarshal(bodyBytes, &decoded); err != nil {
 		return checkRunResponse{}, fmt.Errorf("decode response: %w", err)
 	}
 	return decoded, nil
+}
+
+func (p *Publisher) request(ctx context.Context, method, endpoint string, payload any) ([]byte, error) {
+	var reader io.Reader
+	if payload != nil {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal payload: %w", err)
+		}
+		reader = bytes.NewReader(encoded)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+p.token)
+	request.Header.Set("Accept", acceptContentType)
+	request.Header.Set("X-GitHub-Api-Version", apiVersion)
+	if payload != nil {
+		request.Header.Set("Content-Type", jsonContentType)
+	}
+
+	response, err := p.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("call github: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	bodyBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if !isSuccessStatus(response.StatusCode) {
+		return nil, fmt.Errorf("github %s %s: status %d: %s",
+			method, endpoint, response.StatusCode, strings.TrimSpace(string(bodyBytes)))
+	}
+	return bodyBytes, nil
+}
+
+func (p *Publisher) UpsertComment(ctx context.Context, prNumber int, body string) error {
+	fullBody := commentMarker + "\n" + body
+	existing, err := p.findComment(ctx, prNumber)
+	if err != nil {
+		return err
+	}
+	if existing > 0 {
+		endpoint := fmt.Sprintf("%s/repos/%s/%s/issues/comments/%d", p.baseURL, p.owner, p.repo, existing)
+		_, err := p.request(ctx, http.MethodPatch, endpoint, commentPayload{Body: fullBody})
+		return err
+	}
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments", p.baseURL, p.owner, p.repo, prNumber)
+	_, err = p.request(ctx, http.MethodPost, endpoint, commentPayload{Body: fullBody})
+	return err
+}
+
+func (p *Publisher) findComment(ctx context.Context, prNumber int) (int64, error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments", p.baseURL, p.owner, p.repo, prNumber)
+	bodyBytes, err := p.request(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, err
+	}
+	var comments []commentResponse
+	if err := json.Unmarshal(bodyBytes, &comments); err != nil {
+		return 0, fmt.Errorf("decode comments: %w", err)
+	}
+	for _, comment := range comments {
+		if strings.Contains(comment.Body, commentMarker) {
+			return comment.ID, nil
+		}
+	}
+	return 0, nil
 }
 
 func isSuccessStatus(status int) bool {
@@ -205,4 +253,13 @@ type annotationData struct {
 type checkRunResponse struct {
 	ID      int64  `json:"id"`
 	HTMLURL string `json:"html_url"`
+}
+
+type commentPayload struct {
+	Body string `json:"body"`
+}
+
+type commentResponse struct {
+	ID   int64  `json:"id"`
+	Body string `json:"body"`
 }

--- a/core/userinterface/cli/report/github/publisher_test.go
+++ b/core/userinterface/cli/report/github/publisher_test.go
@@ -3,6 +3,7 @@ package github_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -204,6 +205,25 @@ func TestUpsertCommentErrorsOnMalformedList(t *testing.T) {
 
 func TestPublishErrorsOnUnbuildableRequest(t *testing.T) {
 	publisher, err := github.NewPublisher(github.Config{Token: "secret", Repo: "octo/repo", BaseURL: "://bad"})
+	require.NoError(t, err)
+	_, err = publisher.Publish(context.Background(), checks.CheckRun{Name: "gavel", HeadSHA: "abc"})
+	require.Error(t, err)
+}
+
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+func (errReadCloser) Close() error             { return nil }
+
+type errBodyTransport struct{}
+
+func (errBodyTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: http.StatusOK, Body: errReadCloser{}, Header: make(http.Header)}, nil
+}
+
+func TestPublishErrorsWhenResponseBodyUnreadable(t *testing.T) {
+	client := &http.Client{Transport: errBodyTransport{}}
+	publisher, err := github.NewPublisher(github.Config{Token: "secret", Repo: "octo/repo"}, github.WithClient(client))
 	require.NoError(t, err)
 	_, err = publisher.Publish(context.Background(), checks.CheckRun{Name: "gavel", HeadSHA: "abc"})
 	require.Error(t, err)

--- a/core/userinterface/cli/report/github/publisher_test.go
+++ b/core/userinterface/cli/report/github/publisher_test.go
@@ -129,6 +129,86 @@ func TestPublishReturnsErrorWhenServerUnreachable(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestUpsertCommentCreatesWhenNoneExists(t *testing.T) {
+	var method, calledPath, requestBody string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodGet {
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte(`[]`))
+			return
+		}
+		rawBody, _ := io.ReadAll(request.Body)
+		method, calledPath, requestBody = request.Method, request.URL.Path, string(rawBody)
+		writer.WriteHeader(http.StatusCreated)
+		_, _ = writer.Write([]byte(`{"id": 1}`))
+	}))
+	defer server.Close()
+
+	publisher, err := github.NewPublisher(github.Config{Token: "secret", Repo: "octo/repo", BaseURL: server.URL})
+	require.NoError(t, err)
+	require.NoError(t, publisher.UpsertComment(context.Background(), 7, "the summary"))
+
+	assert.Equal(t, http.MethodPost, method)
+	assert.Equal(t, "/repos/octo/repo/issues/7/comments", calledPath)
+	assert.Contains(t, requestBody, "the summary")
+	assert.Contains(t, requestBody, "gavel-report")
+}
+
+func TestUpsertCommentUpdatesExisting(t *testing.T) {
+	var method, calledPath string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodGet {
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte(`[{"id": 42, "body": "<!-- gavel-report -->\nold"}]`))
+			return
+		}
+		method, calledPath = request.Method, request.URL.Path
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte(`{"id": 42}`))
+	}))
+	defer server.Close()
+
+	publisher, err := github.NewPublisher(github.Config{Token: "secret", Repo: "octo/repo", BaseURL: server.URL})
+	require.NoError(t, err)
+	require.NoError(t, publisher.UpsertComment(context.Background(), 7, "new summary"))
+
+	assert.Equal(t, http.MethodPatch, method)
+	assert.Equal(t, "/repos/octo/repo/issues/comments/42", calledPath)
+}
+
+func TestUpsertCommentErrorsWhenListingFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusForbidden)
+		_, _ = writer.Write([]byte(`{"message":"forbidden"}`))
+	}))
+	defer server.Close()
+
+	publisher, err := github.NewPublisher(github.Config{Token: "secret", Repo: "octo/repo", BaseURL: server.URL})
+	require.NoError(t, err)
+	err = publisher.UpsertComment(context.Background(), 7, "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestUpsertCommentErrorsOnMalformedList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte(`not json`))
+	}))
+	defer server.Close()
+
+	publisher, err := github.NewPublisher(github.Config{Token: "secret", Repo: "octo/repo", BaseURL: server.URL})
+	require.NoError(t, err)
+	require.Error(t, publisher.UpsertComment(context.Background(), 7, "x"))
+}
+
+func TestPublishErrorsOnUnbuildableRequest(t *testing.T) {
+	publisher, err := github.NewPublisher(github.Config{Token: "secret", Repo: "octo/repo", BaseURL: "://bad"})
+	require.NoError(t, err)
+	_, err = publisher.Publish(context.Background(), checks.CheckRun{Name: "gavel", HeadSHA: "abc"})
+	require.Error(t, err)
+}
+
 func TestNewPublisherRejectsInvalidConfig(t *testing.T) {
 	_, err := github.NewPublisher(github.Config{Token: "secret", Repo: "noslash"})
 	assert.Error(t, err, "repo without owner/name must be rejected")

--- a/core/userinterface/cli/report/report.go
+++ b/core/userinterface/cli/report/report.go
@@ -19,6 +19,7 @@ type WorkspaceResolver func() (string, error)
 
 type ChecksPublisher interface {
 	Publish(ctx context.Context, checkRun checks.CheckRun) (github.Result, error)
+	UpsertComment(ctx context.Context, prNumber int, body string) error
 }
 
 type PublisherFactory func(config github.Config) (ChecksPublisher, error)
@@ -95,6 +96,12 @@ func run(ctx context.Context, writer io.Writer, opts Options, resolveWorkspace W
 	result, err := publisher.Publish(ctx, checkRun)
 	if err != nil {
 		return err
+	}
+
+	if opts.PR > 0 {
+		if err := publisher.UpsertComment(ctx, opts.PR, checkRun.Summary); err != nil {
+			return err
+		}
 	}
 
 	if _, err := fmt.Fprintf(writer, "Reported %d project(s) to %s: %s\n",

--- a/core/userinterface/cli/report/report_test.go
+++ b/core/userinterface/cli/report/report_test.go
@@ -17,14 +17,23 @@ import (
 )
 
 type fakePublisher struct {
-	received checks.CheckRun
-	result   github.Result
-	err      error
+	received    checks.CheckRun
+	result      github.Result
+	err         error
+	commentedPR int
+	commentBody string
+	commentErr  error
 }
 
 func (fake *fakePublisher) Publish(_ context.Context, checkRun checks.CheckRun) (github.Result, error) {
 	fake.received = checkRun
 	return fake.result, fake.err
+}
+
+func (fake *fakePublisher) UpsertComment(_ context.Context, prNumber int, body string) error {
+	fake.commentedPR = prNumber
+	fake.commentBody = body
+	return fake.commentErr
 }
 
 type failingWriter struct{}
@@ -219,6 +228,37 @@ func TestReportPropagatesLoadError(t *testing.T) {
 
 	_, err := runReport(workspace, &fakePublisher{}, "--repo=o/r", "--github-token=tok")
 	require.Error(t, err)
+}
+
+func TestReportPostsStickyCommentWhenPRSet(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdict(t, workspace, "core", `{"name":"core","verdict":"pass","commit_sha":"c1"}`)
+	publisher := &fakePublisher{result: github.Result{URL: "u"}}
+
+	_, err := runReport(workspace, publisher, "--repo=o/r", "--github-token=tok", "--pr=7")
+	require.NoError(t, err)
+	assert.Equal(t, 7, publisher.commentedPR)
+	assert.Contains(t, publisher.commentBody, "Gavel verdict")
+}
+
+func TestReportSkipsCommentWithoutPR(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdict(t, workspace, "core", `{"name":"core","verdict":"pass","commit_sha":"c1"}`)
+	publisher := &fakePublisher{result: github.Result{URL: "u"}}
+
+	_, err := runReport(workspace, publisher, "--repo=o/r", "--github-token=tok")
+	require.NoError(t, err)
+	assert.Equal(t, 0, publisher.commentedPR)
+}
+
+func TestReportPropagatesCommentError(t *testing.T) {
+	workspace := t.TempDir()
+	writeVerdict(t, workspace, "core", `{"name":"core","verdict":"pass","commit_sha":"c1"}`)
+	publisher := &fakePublisher{result: github.Result{URL: "u"}, commentErr: errors.New("comment failed")}
+
+	_, err := runReport(workspace, publisher, "--repo=o/r", "--github-token=tok", "--pr=7")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "comment failed")
 }
 
 func TestReportErrorsWithoutCache(t *testing.T) {


### PR DESCRIPTION
## What
`gavel report` now posts and updates a **sticky summary comment** on the pull
request when `--pr` is set, alongside the existing check run.

## Why
The check run is nearly invisible when a PR has zero new findings — a green
check with no inline annotations (exactly what we saw on gavel's own PRs). A
comment in the conversation makes the verdict visible ("core PASS 94.7%, cli
PASS 100%"), which is where developers actually look. Codecov and Sonar do the
same.

## How
- `github.Publisher.UpsertComment` lists the PR's comments, finds the one
  carrying a hidden marker (`<!-- gavel-report -->`), and PATCHes it if present
  or POSTs a new one — so it stays **one sticky comment updated in place**, not
  one per push.
- `report` calls it after the check run when `--pr` is set, reusing the check
  run's summary markdown (single source, no duplication).
- Extracted a shared `request()` helper so the check-run and comment paths reuse
  the HTTP layer.
- The dogfood job gains `pull-requests: write` and passes `--pr`, so **this very
  PR should receive gavel's sticky comment**.

## Testing
- github (httptest): create + update upsert, list-failure and malformed-list
  errors.
- report: comment posted when `--pr` set, skipped without it, error propagated.
- New report/github code at 100% (`run`, `UpsertComment`, `findComment`); two
  defensive branches remain in the shared `request()` — an unreachable
  `json.Marshal` of a plain struct, and a `ReadAll` error that needs transport
  injection.
- `gavel judge --project=core` PASS — 94.7%.

## Risk & scope
- Fork PRs are skipped (read-only token), same guard as the check run.
- A comment failure fails `report` — surfaces misconfiguration (e.g. missing
  `pull-requests: write`).
- The check run stays the merge gate; the comment is visibility only.
