### PR TITLE
fix(core): tool_execution + architecture baseline correctness; bump gavel_tools 0.3.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ bazel_dep(name = "aspect_rules_ts", version = "3.8.8")
 bazel_dep(name = "aspect_rules_esbuild", version = "0.25.1")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
 bazel_dep(name = "rules_rust", version = "0.70.0")
-bazel_dep(name = "gavel_tools", version = "0.3.2")
+bazel_dep(name = "gavel_tools", version = "0.3.3")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.25.0")

--- a/core/domain/casefile/model/tracking/identifier_result.go
+++ b/core/domain/casefile/model/tracking/identifier_result.go
@@ -12,21 +12,32 @@ func ClassifyIdentifiers(current, previous []string) IdentifierResult {
 		prevSet[id] = true
 	}
 
+	currentSet := make(map[string]bool, len(current))
+	for _, id := range current {
+		currentSet[id] = true
+	}
+
 	newIDs := make(map[string]bool)
 	existingCount := 0
-	for _, id := range current {
+	for id := range currentSet {
 		if prevSet[id] {
 			existingCount++
-			delete(prevSet, id)
 		} else {
 			newIDs[id] = true
+		}
+	}
+
+	resolvedCount := 0
+	for id := range prevSet {
+		if !currentSet[id] {
+			resolvedCount++
 		}
 	}
 
 	return IdentifierResult{
 		newIdentifiers: newIDs,
 		existingCount:  existingCount,
-		resolvedCount:  len(prevSet),
+		resolvedCount:  resolvedCount,
 	}
 }
 

--- a/core/domain/casefile/model/tracking/result_test.go
+++ b/core/domain/casefile/model/tracking/result_test.go
@@ -173,13 +173,22 @@ func TestClassifyIdentifiers(t *testing.T) {
 			wantNewIDs:        map[string]bool{},
 		},
 		{
-			name:              "duplicates input current inflate counts when not deduplicated",
+			name:              "duplicate current ids are deduplicated as a set",
 			current:           []string{"a", "b", "a"},
 			previous:          []string{"a"},
-			wantNewCount:      2,
+			wantNewCount:      1,
 			wantExistingCount: 1,
 			wantResolvedCount: 0,
-			wantNewIDs:        map[string]bool{"a": true, "b": true},
+			wantNewIDs:        map[string]bool{"b": true},
+		},
+		{
+			name:              "repeated existing id counts once and is never new",
+			current:           []string{"a", "a", "a"},
+			previous:          []string{"a"},
+			wantNewCount:      0,
+			wantExistingCount: 1,
+			wantResolvedCount: 0,
+			wantNewIDs:        map[string]bool{},
 		},
 	}
 

--- a/core/infrastructure/casefile/sarif/executions.go
+++ b/core/infrastructure/casefile/sarif/executions.go
@@ -10,10 +10,6 @@ import (
 
 const unknownTool = "unknown"
 
-// ParseToolExecutions extracts the analyzer runs that did not complete from a
-// SARIF document: each invocation with executionSuccessful=false becomes a tool
-// failure carrying its tool name and the concrete reason from the
-// toolExecutionNotifications. A clean document yields no failures.
 func (*Parser) ParseToolExecutions(data []byte) ([]evidencedto.ToolFailure, error) {
 	if len(data) == 0 {
 		return nil, nil
@@ -31,7 +27,7 @@ func (*Parser) ParseToolExecutions(data []byte) ([]evidencedto.ToolFailure, erro
 			toolName = unknownTool
 		}
 		for _, inv := range currentRun.Invocations {
-			if inv.ExecutionSuccessful {
+			if inv.ExecutionSuccessful || isConfigurationOnly(inv) {
 				continue
 			}
 			failures = append(failures, evidencedto.ToolFailure{
@@ -41,6 +37,10 @@ func (*Parser) ParseToolExecutions(data []byte) ([]evidencedto.ToolFailure, erro
 		}
 	}
 	return failures, nil
+}
+
+func isConfigurationOnly(inv invocation) bool {
+	return len(inv.ToolExecutionNotifications) == 0 && len(inv.ToolConfigurationNotifications) > 0
 }
 
 func invocationReason(inv invocation) string {

--- a/core/infrastructure/casefile/sarif/executions.go
+++ b/core/infrastructure/casefile/sarif/executions.go
@@ -8,7 +8,10 @@ import (
 	"github.com/usegavel/gavel/core/application/casefile/evidencedto"
 )
 
-const unknownTool = "unknown"
+const (
+	unknownTool = "unknown"
+	errorLevel  = "error"
+)
 
 func (*Parser) ParseToolExecutions(data []byte) ([]evidencedto.ToolFailure, error) {
 	if len(data) == 0 {
@@ -40,18 +43,36 @@ func (*Parser) ParseToolExecutions(data []byte) ([]evidencedto.ToolFailure, erro
 }
 
 func isConfigurationOnly(inv invocation) bool {
-	return len(inv.ToolExecutionNotifications) == 0 && len(inv.ToolConfigurationNotifications) > 0
+	if len(inv.ToolExecutionNotifications) > 0 || len(inv.ToolConfigurationNotifications) == 0 {
+		return false
+	}
+	return !hasErrorNotification(inv.ToolConfigurationNotifications)
+}
+
+func hasErrorNotification(notes []notification) bool {
+	for _, note := range notes {
+		if strings.EqualFold(strings.TrimSpace(note.Level), errorLevel) {
+			return true
+		}
+	}
+	return false
 }
 
 func invocationReason(inv invocation) string {
-	reasons := make([]string, 0, len(inv.ToolExecutionNotifications))
-	for _, note := range inv.ToolExecutionNotifications {
-		if text := strings.TrimSpace(note.Message.Text); text != "" {
-			reasons = append(reasons, text)
-		}
-	}
+	reasons := make([]string, 0, len(inv.ToolExecutionNotifications)+len(inv.ToolConfigurationNotifications))
+	reasons = appendNotificationTexts(reasons, inv.ToolExecutionNotifications)
+	reasons = appendNotificationTexts(reasons, inv.ToolConfigurationNotifications)
 	if len(reasons) == 0 {
 		return "analyzer reported an unsuccessful run"
 	}
 	return strings.Join(reasons, "; ")
+}
+
+func appendNotificationTexts(reasons []string, notes []notification) []string {
+	for _, note := range notes {
+		if text := strings.TrimSpace(note.Message.Text); text != "" {
+			reasons = append(reasons, text)
+		}
+	}
+	return reasons
 }

--- a/core/infrastructure/casefile/sarif/executions_test.go
+++ b/core/infrastructure/casefile/sarif/executions_test.go
@@ -55,6 +55,37 @@ func TestParseToolExecutionsIgnoresConfigurationOnlyNotifications(t *testing.T) 
 	assert.Empty(t, failures)
 }
 
+func TestParseToolExecutionsFailsOnErrorLevelConfigurationNotification(t *testing.T) {
+	data := []byte(`{"runs":[{"tool":{"driver":{"name":"pmd"}},"results":[],"invocations":[{"executionSuccessful":false,"toolConfigurationNotifications":[{"level":"error","message":{"text":"ruleset failed to load"}}]}]}]}`)
+
+	failures, err := NewParser().ParseToolExecutions(data)
+
+	require.NoError(t, err)
+	require.Len(t, failures, 1)
+	assert.Equal(t, "pmd", failures[0].Tool)
+	assert.Contains(t, failures[0].Reason, "ruleset failed to load")
+}
+
+func TestParseToolExecutionsIgnoresWarningLevelConfigurationNotification(t *testing.T) {
+	data := []byte(`{"runs":[{"tool":{"driver":{"name":"PMD"}},"results":[],"invocations":[{"executionSuccessful":false,"toolConfigurationNotifications":[{"level":"warning","message":{"text":"rule needs configuration"}}]}]}]}`)
+
+	failures, err := NewParser().ParseToolExecutions(data)
+
+	require.NoError(t, err)
+	assert.Empty(t, failures)
+}
+
+func TestParseToolExecutionsSurfacesConfigurationReasonAlongsideExecution(t *testing.T) {
+	data := []byte(`{"runs":[{"tool":{"driver":{"name":"pmd"}},"results":[],"invocations":[{"executionSuccessful":false,"toolExecutionNotifications":[{"message":{"text":"analysis aborted"}}],"toolConfigurationNotifications":[{"level":"error","message":{"text":"invalid ruleset path"}}]}]}]}`)
+
+	failures, err := NewParser().ParseToolExecutions(data)
+
+	require.NoError(t, err)
+	require.Len(t, failures, 1)
+	assert.Contains(t, failures[0].Reason, "analysis aborted")
+	assert.Contains(t, failures[0].Reason, "invalid ruleset path")
+}
+
 func TestParseToolExecutionsEmptyData(t *testing.T) {
 	failures, err := NewParser().ParseToolExecutions(nil)
 

--- a/core/infrastructure/casefile/sarif/executions_test.go
+++ b/core/infrastructure/casefile/sarif/executions_test.go
@@ -46,6 +46,15 @@ func TestParseToolExecutionsFailureWithoutNotifications(t *testing.T) {
 	assert.NotEmpty(t, failures[0].Reason)
 }
 
+func TestParseToolExecutionsIgnoresConfigurationOnlyNotifications(t *testing.T) {
+	data := []byte(`{"runs":[{"tool":{"driver":{"name":"PMD"}},"results":[],"invocations":[{"executionSuccessful":false,"toolConfigurationNotifications":[{"message":{"text":"No packages or classes specified"}}],"toolExecutionNotifications":[]}]}]}`)
+
+	failures, err := NewParser().ParseToolExecutions(data)
+
+	require.NoError(t, err)
+	assert.Empty(t, failures)
+}
+
 func TestParseToolExecutionsEmptyData(t *testing.T) {
 	failures, err := NewParser().ParseToolExecutions(nil)
 

--- a/core/infrastructure/casefile/sarif/invocation.go
+++ b/core/infrastructure/casefile/sarif/invocation.go
@@ -1,8 +1,9 @@
 package sarif
 
 type invocation struct {
-	ExecutionSuccessful        bool           `json:"executionSuccessful"`
-	ToolExecutionNotifications []notification `json:"toolExecutionNotifications"`
+	ExecutionSuccessful            bool           `json:"executionSuccessful"`
+	ToolExecutionNotifications     []notification `json:"toolExecutionNotifications"`
+	ToolConfigurationNotifications []notification `json:"toolConfigurationNotifications"`
 }
 
 type notification struct {

--- a/core/infrastructure/casefile/sarif/invocation.go
+++ b/core/infrastructure/casefile/sarif/invocation.go
@@ -7,5 +7,6 @@ type invocation struct {
 }
 
 type notification struct {
+	Level   string  `json:"level"`
 	Message message `json:"message"`
 }

--- a/core/infrastructure/platform/bazel/installer/install_test.go
+++ b/core/infrastructure/platform/bazel/installer/install_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/usegavel/gavel/core/infrastructure/platform/bazel/installer"
 )
 
-const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.2")`
+const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.3")`
 
 const (
 	gavelRegistryLine = "common --registry=https://gavelcode.github.io/registry"

--- a/core/infrastructure/platform/bazel/installer/installer.go
+++ b/core/infrastructure/platform/bazel/installer/installer.go
@@ -24,7 +24,7 @@ const moduleInclude = `include("//:.gavel/gavel.MODULE.bazel")`
 
 const GavelBazelrc = ".gavel/gavel.bazelrc"
 const GavelModule = ".gavel/gavel.MODULE.bazel"
-const gavelToolsVersion = "0.3.2"
+const gavelToolsVersion = "0.3.3"
 const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "` + gavelToolsVersion + `")`
 
 type Installer struct{}

--- a/examples/go-repo/MODULE.bazel
+++ b/examples/go-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.1.0")
+bazel_dep(name = "gavel_tools", version = "0.3.3")
 bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "gazelle", version = "0.50.0")
 

--- a/examples/java-repo/MODULE.bazel
+++ b/examples/java-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.1.0")
+bazel_dep(name = "gavel_tools", version = "0.3.3")
 bazel_dep(name = "rules_java", version = "9.1.0")
 
 include("//:.gavel/gavel.MODULE.bazel")

--- a/examples/python-repo/MODULE.bazel
+++ b/examples/python-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.1.0")
+bazel_dep(name = "gavel_tools", version = "0.3.3")
 bazel_dep(name = "rules_python", version = "1.7.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/examples/rust-fullstack-repo/MODULE.bazel
+++ b/examples/rust-fullstack-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.1.0")
+bazel_dep(name = "gavel_tools", version = "0.3.3")
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "aspect_rules_js", version = "3.0.3")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.8")

--- a/examples/rust-fullstack-repo/frontend/BUILD.bazel
+++ b/examples/rust-fullstack-repo/frontend/BUILD.bazel
@@ -6,7 +6,13 @@ npm_link_all_packages(name = "node_modules")
 
 js_library(
     name = "frontend",
-    srcs = glob(["src/**/*.ts", "src/**/*.tsx"]),
+    srcs = glob(["src/**/*.ts", "src/**/*.tsx"]) + ["eslint.config.js"],
+    deps = [
+        ":node_modules/@eslint/js",
+        ":node_modules/eslint-plugin-react-hooks",
+        ":node_modules/eslint-plugin-react-refresh",
+        ":node_modules/typescript-eslint",
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Bundles the fixes surfaced while proving gavel runs clean on the `examples/` monorepos under the latest analyzers.

## Commits
1. **fix(core): don't fail tool_execution on config-only SARIF notifications** — a `toolConfigurationNotifications`-only invocation (e.g. PMD's LoosePackageCoupling warning) no longer fails the tool_execution gate; a real `toolExecutionNotifications` error still does.
2. **fix(core): classify architecture identifiers as a set** — `ClassifyIdentifiers` consumed the single baseline entry on the first match, so repeated arch ids (multiple Bazel targets reporting the same `rule:from:to`) surfaced as "1 new" forever. Now set-based. Fixed the python example's `architecture: FAIL` → `PASS` with no reseed.
3. **fix(examples): wire the rust frontend eslint config into its js_library** — the aspect harvests the flat config + plugins from JsInfo; the js_library exposed neither, so ESLint 10 (shipped by 0.3.3) exited 2. Added `eslint.config.js` to srcs + the plugin deps.
4. **build(deps): bump gavel_tools 0.3.2 → 0.3.3** — project-gavel + all four examples.

## Verification
- Full dogfood on 0.3.3 + these fixes: **core / cli / server / web / tools all PASS**, 0 new findings, core coverage 94.8% (↑0.1%).
- All four examples (java · go · python · rust-fullstack) now report **tool_execution: PASS**.