### PR TITLE
ci: prove onboarding by judging the examples on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,62 @@ jobs:
 
       - name: CLI spec drift (flags.gen.go)
         run: make clispec-check
+
+  # Onboarding proof: gavel must run cleanly on a fresh project. Each example is
+  # its own Bazel workspace pinning the published gavel_tools; we build gavel
+  # from source and assert every analyzer actually ran. The examples
+  # intentionally fail coverage/architecture, so the gate keys off
+  # tool_execution alone, not the overall verdict — this is what would have
+  # caught the ESLint-exit-2 and PMD config-notification regressions.
+  onboarding:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        example: [go-repo, java-repo, python-repo, rust-fullstack-repo]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Bazel
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/bazel
+          key: bazel-onboarding-${{ matrix.example }}-${{ hashFiles('MODULE.bazel.lock', '.bazelversion') }}
+          restore-keys: bazel-onboarding-${{ matrix.example }}-
+
+      - name: Install Bazelisk
+        run: |
+          sudo curl -fsSL -o /usr/local/bin/bazel \
+            https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
+          sudo chmod +x /usr/local/bin/bazel
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install pnpm
+        run: npm install -g pnpm@9.15.4
+
+      # gavel collects TypeScript coverage by running `npx vitest run` in the
+      # project directory, so a frontend example needs its host node_modules.
+      - name: Install example frontend deps
+        run: |
+          if [ -f "examples/${{ matrix.example }}/frontend/package.json" ]; then
+            cd "examples/${{ matrix.example }}/frontend"
+            pnpm install --frozen-lockfile
+          fi
+
+      - name: Build gavel CLI
+        run: bazel build //apps/cli/cmd/gavel
+
+      - name: Judge the example and assert every analyzer ran
+        run: |
+          gavel="$PWD/bazel-bin/apps/cli/cmd/gavel/gavel_/gavel"
+          cd "examples/${{ matrix.example }}"
+          "$gavel" judge --json > result.json || true
+          echo "tool_execution per project:"
+          jq -r '.projects[] | "  \(.name): \([.rulings[] | select(.subtype == "tool_execution").passed][0])"' result.json
+          jq -e '([.projects[].rulings[] | select(.subtype == "tool_execution")]) as $te
+                 | ($te | length > 0) and ($te | all(.passed == true))' result.json > /dev/null \
+            || { echo "::error::an analyzer failed to run (tool_execution) in ${{ matrix.example }}"; exit 1; }

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ bazel_dep(name = "aspect_rules_ts", version = "3.8.8")
 bazel_dep(name = "aspect_rules_esbuild", version = "0.25.1")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
 bazel_dep(name = "rules_rust", version = "0.70.0")
-bazel_dep(name = "gavel_tools", version = "0.3.3")
+bazel_dep(name = "gavel_tools", version = "0.3.4")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.25.0")

--- a/core/infrastructure/platform/bazel/installer/install_test.go
+++ b/core/infrastructure/platform/bazel/installer/install_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/usegavel/gavel/core/infrastructure/platform/bazel/installer"
 )
 
-const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.3")`
+const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.4")`
 
 const (
 	gavelRegistryLine = "common --registry=https://gavelcode.github.io/registry"

--- a/core/infrastructure/platform/bazel/installer/installer.go
+++ b/core/infrastructure/platform/bazel/installer/installer.go
@@ -24,7 +24,7 @@ const moduleInclude = `include("//:.gavel/gavel.MODULE.bazel")`
 
 const GavelBazelrc = ".gavel/gavel.bazelrc"
 const GavelModule = ".gavel/gavel.MODULE.bazel"
-const gavelToolsVersion = "0.3.3"
+const gavelToolsVersion = "0.3.4"
 const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "` + gavelToolsVersion + `")`
 
 type Installer struct{}

--- a/examples/go-repo/MODULE.bazel
+++ b/examples/go-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.3")
+bazel_dep(name = "gavel_tools", version = "0.3.4")
 bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "gazelle", version = "0.50.0")
 

--- a/examples/java-repo/MODULE.bazel
+++ b/examples/java-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.3")
+bazel_dep(name = "gavel_tools", version = "0.3.4")
 bazel_dep(name = "rules_java", version = "9.1.0")
 
 include("//:.gavel/gavel.MODULE.bazel")

--- a/examples/python-repo/MODULE.bazel
+++ b/examples/python-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.3")
+bazel_dep(name = "gavel_tools", version = "0.3.4")
 bazel_dep(name = "rules_python", version = "1.7.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/examples/rust-fullstack-repo/MODULE.bazel
+++ b/examples/rust-fullstack-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.3")
+bazel_dep(name = "gavel_tools", version = "0.3.4")
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "aspect_rules_js", version = "3.0.3")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.8")


### PR DESCRIPTION
Adds an `onboarding` matrix job (one leg per example: go · java · python · rust-fullstack) that builds gavel from source, runs `gavel judge --json` in each example workspace, and asserts every project's **tool_execution** ruling passed.

## Why
Nothing in CI exercised gavel on a fresh project. Regressions in the analyzer aspects only surfaced manually — this session alone found ESLint exiting 2 (unwired flat config) and PMD failing tool_execution on a config-only notification. This job would have caught both.

## Design
- **Keys off `tool_execution` only**, not the overall verdict — the examples intentionally fail coverage/architecture, so a FAIL verdict is expected; a non-running analyzer is not.
- **Linux-only, every PR + push** (per cost/coverage tradeoff).
- `fail-fast: false` so all four example statuses are visible.
- The rust-fullstack leg installs its frontend `node_modules` because gavel collects TS coverage via `npx vitest run` on the host.

Verified the build→judge→assert mechanism end-to-end locally against all four examples on gavel_tools 0.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)