### PR TITLE
fix(cli): embed the tool catalog so the distributed binary runs standalone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,9 @@ jobs:
       - name: CLI spec drift (flags.gen.go)
         run: make clispec-check
 
+      - name: Catalog drift (embedded gavel_tools catalog)
+        run: make catalog-check
+
   # Onboarding proof: gavel must run cleanly on a fresh project. Each example is
   # its own Bazel workspace pinning the published gavel_tools; we build gavel
   # from source and assert every analyzer actually ran. The examples

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ V1_GEN_DIR := $(V1_DIR)/gen
 V1_SPEC := openapi/v1/openapi.yaml
 V1_BUNDLE := /tmp/gavel-openapi-bundled.yaml
 
-.PHONY: openapi-bundle openapi-gen openapi-gen-ts openapi-check clispec-gen clispec-check e2e release
+CATALOG_DST := core/infrastructure/platform/bazel/catalog/catalog.yaml
+
+.PHONY: openapi-bundle openapi-gen openapi-gen-ts openapi-check clispec-gen clispec-check catalog-sync catalog-check e2e release
 
 # openapi-bundle uses @redocly/cli to inline the split spec under openapi/v1/
 # into a single self-contained YAML. Both code generators (Go via oapi-codegen,
@@ -31,6 +33,17 @@ clispec-check: clispec-gen
 	@git diff --exit-code -- core/userinterface/cli/*/flags.gen.go \
 		|| (echo "clispec drift detected: run 'make clispec-gen' and commit"; exit 1)
 	bazel test //apps/cli/test/integration/clispec/...
+
+# catalog-sync vendors gavel_tools' tool catalog into the CLI so the distributed
+# standalone binary carries it (go:embed) instead of reading it from Bazel
+# runfiles it does not ship. The pinned gavel_tools version is the source of truth.
+catalog-sync:
+	@bazel build @gavel_tools//lint:catalog.yaml >/dev/null 2>&1
+	@cp "$$(bazel info execution_root)/$$(bazel cquery --output=files @gavel_tools//lint:catalog.yaml 2>/dev/null)" $(CATALOG_DST)
+
+catalog-check: catalog-sync
+	@git diff --exit-code -- $(CATALOG_DST) \
+		|| (echo "catalog drift detected: run 'make catalog-sync' and commit"; exit 1)
 
 e2e:
 	bazel build //apps/server/cmd/gavel-server

--- a/core/infrastructure/platform/bazel/catalog/BUILD.bazel
+++ b/core/infrastructure/platform/bazel/catalog/BUILD.bazel
@@ -10,12 +10,10 @@ go_library(
         "load.go",
         "tool_repo.go",
     ],
+    embedsrcs = ["catalog.yaml"],
     importpath = "github.com/usegavel/gavel/core/infrastructure/platform/bazel/catalog",
     visibility = ["//visibility:public"],
-    deps = [
-        "@in_gopkg_yaml_v3//:yaml_v3",
-        "@rules_go//go/runfiles",
-    ],
+    deps = ["@in_gopkg_yaml_v3//:yaml_v3"],
 )
 
 go_test(
@@ -24,7 +22,6 @@ go_test(
         "catalog_test.go",
         "load_test.go",
     ],
-    data = ["@gavel_tools//lint:catalog.yaml"],
     embed = [":catalog"],
     deps = [
         "@com_github_stretchr_testify//assert",

--- a/core/infrastructure/platform/bazel/catalog/catalog.yaml
+++ b/core/infrastructure/platform/bazel/catalog/catalog.yaml
@@ -1,0 +1,77 @@
+# The gavel-tools catalog: the menu of what this module can lint, per language.
+#
+# This is the single source of truth a consumer (e.g. gavel) reads to know which
+# tools exist, which aspect runs each one, what SARIF file it emits, which build
+# flags it needs, and which tool-binary repo it depends on. The consumer's
+# gavel.yaml then *selects* tools from this menu per project — it never redefines
+# what a tool is.
+#
+# Each aspect listed here must exist in //lint/aspects:defs.bzl; that consistency
+# is enforced by catalog_test. `binary` and `build_flags` are optional (only the
+# tools that need them carry them). `aspects_bzl` is the module-relative label
+# where the aspects live; a consumer prefixes it with the module name it binds
+# gavel_tools under.
+version: 1
+aspects_bzl: //lint/aspects:defs.bzl
+languages:
+  go:
+    - name: golangci-lint
+      aspect: go_golangci_lint_submission_aspect
+      sarif_suffix: .golangci.sarif
+      build_flags: ["--@rules_go//go/config:export_stdlib=True"]
+      binary: golangci_lint_binary
+    - name: archtest
+      aspect: go_archtest_submission_aspect
+      sarif_suffix: .archtest.sarif
+  java:
+    - name: pmd
+      aspect: java_pmd_submission_aspect
+      sarif_suffix: .pmd.sarif
+      binary: pmd_binary
+    - name: cpd
+      aspect: java_cpd_submission_aspect
+      sarif_suffix: .cpd.sarif
+      binary: pmd_binary
+    - name: spotbugs
+      aspect: java_spotbugs_submission_aspect
+      sarif_suffix: .spotbugs.sarif
+      binary: spotbugs_binary
+    - name: error-prone
+      aspect: java_error_prone_submission_aspect
+      sarif_suffix: .errorprone.sarif
+      binary: error_prone_binary
+    - name: archtest
+      aspect: java_archtest_submission_aspect
+      sarif_suffix: .archtest.sarif
+  python:
+    - name: ruff
+      aspect: python_ruff_submission_aspect
+      sarif_suffix: .ruff.sarif
+      binary: ruff_binary
+    - name: bandit
+      aspect: python_bandit_submission_aspect
+      sarif_suffix: .bandit.sarif
+      binary: bandit_binary
+    - name: pycompile
+      aspect: python_pycompile_submission_aspect
+      sarif_suffix: .pycompile.sarif
+    - name: archtest
+      aspect: python_archtest_submission_aspect
+      sarif_suffix: .archtest.sarif
+  typescript:
+    - name: eslint
+      aspect: typescript_eslint_submission_aspect
+      sarif_suffix: .eslint.sarif
+    - name: archtest
+      aspect: typescript_archtest_submission_aspect
+      sarif_suffix: .archtest.sarif
+  rust:
+    - name: clippy
+      aspect: rust_clippy_submission_aspect
+      sarif_suffix: .clippy.sarif
+      build_flags:
+        - "--@rules_rust//rust/settings:capture_clippy_output=True"
+        - "--@rules_rust//rust/settings:clippy_output_diagnostics=True"
+    - name: archtest
+      aspect: rust_archtest_submission_aspect
+      sarif_suffix: .archtest.sarif

--- a/core/infrastructure/platform/bazel/catalog/load.go
+++ b/core/infrastructure/platform/bazel/catalog/load.go
@@ -1,17 +1,22 @@
 package catalog
 
 import (
+	_ "embed"
 	"fmt"
-	"os"
-
-	"github.com/bazelbuild/rules_go/go/runfiles"
 )
 
-const catalogRunfile = "gavel_tools/lint/catalog.yaml"
+// catalog.yaml is synced from @gavel_tools//lint/catalog.yaml by `make
+// catalog-sync` and kept in lockstep by `make catalog-check`. Embedding it —
+// rather than reading it from Bazel runfiles — is what lets the distributed
+// standalone binary run `init` and `judge` off a Bazel workspace it did not
+// build itself.
+//
+//go:embed catalog.yaml
+var embeddedCatalog []byte
 
 var loaded *Catalog
 
-var loader = loadFromRunfiles
+var loader = loadEmbedded
 
 func active() *Catalog {
 	if loaded == nil {
@@ -24,20 +29,8 @@ func active() *Catalog {
 	return loaded
 }
 
-func loadFromRunfiles() (*Catalog, error) {
-	return loadCatalog(runfiles.Rlocation, os.ReadFile)
-}
-
-func loadCatalog(resolvePath func(string) (string, error), readFile func(string) ([]byte, error)) (*Catalog, error) {
-	path, err := resolvePath(catalogRunfile)
-	if err != nil {
-		return nil, fmt.Errorf("locate %s: %w", catalogRunfile, err)
-	}
-	data, err := readFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", path, err)
-	}
-	return ParseCatalog(data)
+func loadEmbedded() (*Catalog, error) {
+	return ParseCatalog(embeddedCatalog)
 }
 
 func SetCatalog(catalog *Catalog) {

--- a/core/infrastructure/platform/bazel/catalog/load_test.go
+++ b/core/infrastructure/platform/bazel/catalog/load_test.go
@@ -8,40 +8,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoadFromRunfiles_ReadsPublishedCatalog(t *testing.T) {
-	parsed, err := loadFromRunfiles()
+func TestEmbeddedCatalog_IsBundledIntoTheBinary(t *testing.T) {
+	assert.NotEmpty(t, embeddedCatalog, "catalog.yaml must be embedded so the standalone binary carries it")
+}
+
+func TestLoadEmbedded_ParsesTheBundledCatalog(t *testing.T) {
+	parsed, err := loadEmbedded()
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, parsed.languages)
 	assert.NotEmpty(t, parsed.aspectsBzl)
-	assert.NotEmpty(t, parsed.languages["go"], "the published catalog must list go tools")
+	assert.NotEmpty(t, parsed.languages["go"], "the bundled catalog must list go tools")
+	assert.NotEmpty(t, parsed.languages["rust"], "the bundled catalog must list rust tools")
 }
 
-func TestActive_LoadsLazilyFromRunfiles(t *testing.T) {
+func TestActive_LoadsLazily(t *testing.T) {
 	loaded = nil
 	t.Cleanup(func() { loaded = nil })
 
 	got := active()
 
 	assert.NotEmpty(t, got.languages)
-}
-
-func TestLoadCatalog_ResolveError(t *testing.T) {
-	_, err := loadCatalog(
-		func(string) (string, error) { return "", errors.New("missing runfile") },
-		func(string) ([]byte, error) { return nil, nil },
-	)
-
-	assert.ErrorContains(t, err, "locate")
-}
-
-func TestLoadCatalog_ReadError(t *testing.T) {
-	_, err := loadCatalog(
-		func(string) (string, error) { return "/some/path", nil },
-		func(string) ([]byte, error) { return nil, errors.New("read failed") },
-	)
-
-	assert.ErrorContains(t, err, "read")
 }
 
 func TestActive_PanicsWhenTheCatalogCannotLoad(t *testing.T) {


### PR DESCRIPTION
## The bug
The distributed binary was broken for its two core commands. gavel loaded the gavel_tools tool catalog from a Bazel runfile (`runfiles.Rlocation("gavel_tools/lint/catalog.yaml")`), but the shipped artifact is a goreleaser `go build` with no runfile tree — so `gavel init` and `gavel judge` **panicked on startup** the moment they touched the catalog:

```
panic: catalog: locate gavel_tools/lint/catalog.yaml: runfiles: no runfiles found
```

Only the author's `bazel run` binary worked. v0.1.0 predated the runfile migration (it shipped a hardcoded catalog), so the regression went unnoticed — nothing in CI exercised the standalone binary. This is precisely the "environment dependency" the alpha→beta exit criterion targets.

## The fix
Vendor the catalog into the package and `go:embed` it, so it travels with the binary and loads identically under Bazel and standalone. `make catalog-sync` copies it from the pinned gavel_tools; `make catalog-check` gates drift in CI, mirroring `openapi-check`/`clispec-check`.

## Verified
- Dogfood core PASS (coverage ↑0.1% from the new tests).
- A standalone `go build` binary runs **`gavel init` → `gavel judge` against a real third-party monorepo (bazel-gazelle)** with no panic — the catalog loads from the embed and the analyzer command is constructed correctly.

## Follow-ups (separate)
- **e2e CI job** driving the distributed binary on a linux+darwin matrix (Phase 2 of blocker #1).
- The bazel-gazelle run surfaced a **gavel_tools robustness gap**: the go `export_stdlib` build_flag hardcodes `@rules_go`, which breaks on repos that alias rules_go under a different repo_name (gazelle uses `io_bazel_rules_go`).