### PR TITLE
build(deps): bump gavel_tools 0.3.4 -> 0.3.5

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ bazel_dep(name = "aspect_rules_ts", version = "3.8.8")
 bazel_dep(name = "aspect_rules_esbuild", version = "0.25.1")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
 bazel_dep(name = "rules_rust", version = "0.70.0")
-bazel_dep(name = "gavel_tools", version = "0.3.4")
+bazel_dep(name = "gavel_tools", version = "0.3.5")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.25.0")

--- a/core/infrastructure/platform/bazel/catalog/catalog.yaml
+++ b/core/infrastructure/platform/bazel/catalog/catalog.yaml
@@ -18,7 +18,10 @@ languages:
     - name: golangci-lint
       aspect: go_golangci_lint_submission_aspect
       sarif_suffix: .golangci.sarif
-      build_flags: ["--@rules_go//go/config:export_stdlib=True"]
+      # Canonical repo name (@@rules_go+) so this flag resolves even when the
+      # consumer aliases rules_go under a different apparent name — e.g. gazelle's
+      # io_bazel_rules_go, where a plain --@rules_go flag fails to resolve.
+      build_flags: ["--@@rules_go+//go/config:export_stdlib=True"]
       binary: golangci_lint_binary
     - name: archtest
       aspect: go_archtest_submission_aspect

--- a/core/infrastructure/platform/bazel/installer/install_test.go
+++ b/core/infrastructure/platform/bazel/installer/install_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/usegavel/gavel/core/infrastructure/platform/bazel/installer"
 )
 
-const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.4")`
+const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.5")`
 
 const (
 	gavelRegistryLine = "common --registry=https://gavelcode.github.io/registry"

--- a/core/infrastructure/platform/bazel/installer/installer.go
+++ b/core/infrastructure/platform/bazel/installer/installer.go
@@ -24,7 +24,7 @@ const moduleInclude = `include("//:.gavel/gavel.MODULE.bazel")`
 
 const GavelBazelrc = ".gavel/gavel.bazelrc"
 const GavelModule = ".gavel/gavel.MODULE.bazel"
-const gavelToolsVersion = "0.3.4"
+const gavelToolsVersion = "0.3.5"
 const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "` + gavelToolsVersion + `")`
 
 type Installer struct{}

--- a/examples/go-repo/MODULE.bazel
+++ b/examples/go-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.4")
+bazel_dep(name = "gavel_tools", version = "0.3.5")
 bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "gazelle", version = "0.50.0")
 

--- a/examples/java-repo/MODULE.bazel
+++ b/examples/java-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.4")
+bazel_dep(name = "gavel_tools", version = "0.3.5")
 bazel_dep(name = "rules_java", version = "9.1.0")
 
 include("//:.gavel/gavel.MODULE.bazel")

--- a/examples/python-repo/MODULE.bazel
+++ b/examples/python-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.4")
+bazel_dep(name = "gavel_tools", version = "0.3.5")
 bazel_dep(name = "rules_python", version = "1.7.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/examples/rust-fullstack-repo/MODULE.bazel
+++ b/examples/rust-fullstack-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.4")
+bazel_dep(name = "gavel_tools", version = "0.3.5")
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "aspect_rules_js", version = "3.0.3")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.8")


### PR DESCRIPTION
0.3.5 writes the go `export_stdlib` flag with rules_go's **canonical** name (`@@rules_go+`), so it resolves on consumers that alias rules_go under a different apparent name. Without it, `gavel judge` aborted golangci-lint on any such repo.

Verified end to end before release: a standalone binary now onboards and judges **bazel-gazelle** (which names rules_go `io_bazel_rules_go`) with `tool_execution: PASS`; the go example is unchanged.

Bumps project-gavel, the installer's scaffold pin (kept in lockstep by installer_test), and all four examples, and re-syncs the embedded catalog (`make catalog-sync` → the drift gate stays green).