### PR TITLE
fix(architecture): restore Go arch enforcement (baseline ratchet + gavel_tools 0.3.6)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ bazel_dep(name = "aspect_rules_ts", version = "3.8.8")
 bazel_dep(name = "aspect_rules_esbuild", version = "0.25.1")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
 bazel_dep(name = "rules_rust", version = "0.70.0")
-bazel_dep(name = "gavel_tools", version = "0.3.5")
+bazel_dep(name = "gavel_tools", version = "0.3.6")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.25.7")

--- a/core/application/casefile/collectevidence/handler.go
+++ b/core/application/casefile/collectevidence/handler.go
@@ -97,6 +97,7 @@ func (h *Handler) Execute(ctx context.Context, cmd Command) (Result, error) {
 	var rawLCOV []byte
 	var archEvidence *evidencedto.Evidence
 	var archCount int
+	var archIDs []string
 	var archDelta classifyarch.Result
 
 	if !cmd.Quick() {
@@ -105,7 +106,7 @@ func (h *Handler) Execute(ctx context.Context, cmd Command) (Result, error) {
 			return Result{}, err
 		}
 
-		archEvidence, archCount, archDelta, err = h.collectArchitecture(ctx, cmd, targets, &evidences)
+		archEvidence, archCount, archIDs, archDelta, err = h.collectArchitecture(ctx, cmd, targets, &evidences)
 		if err != nil {
 			return Result{}, err
 		}
@@ -115,8 +116,6 @@ func (h *Handler) Execute(ctx context.Context, cmd Command) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-
-	archIDs := evidencedto.ExtractArchIDs(evidencedto.ExtractViolations(archEvidence))
 
 	var nccPercent float64
 	if !cmd.Quick() && rawLCOV != nil && h.ingestNCC != nil && h.changedLines != nil {
@@ -226,19 +225,19 @@ func (h *Handler) coverageByFile(rawLCOV []byte) ([]evidencedto.FileCoverage, er
 	return evidencedto.FileCoverageFromPerLine(perLine), nil
 }
 
-func (h *Handler) collectArchitecture(ctx context.Context, cmd Command, targets []string, evidences *[]evidencedto.Evidence) (*evidencedto.Evidence, int, classifyarch.Result, error) {
+func (h *Handler) collectArchitecture(ctx context.Context, cmd Command, targets []string, evidences *[]evidencedto.Evidence) (*evidencedto.Evidence, int, []string, classifyarch.Result, error) {
 	if h.architecture == nil {
-		return nil, 0, classifyarch.Result{}, nil
+		return nil, 0, nil, classifyarch.Result{}, nil
 	}
 	archEv, archDocs, err := h.architecture.CollectViolations(ctx, cmd.Workspace(), targets, cmd.ToolSelection())
 	if err != nil {
-		return nil, 0, classifyarch.Result{}, fmt.Errorf("architecture: %w", err)
+		return nil, 0, nil, classifyarch.Result{}, fmt.Errorf("architecture: %w", err)
 	}
 
 	_ = archDocs
 
 	if archEv == nil {
-		return nil, 0, classifyarch.Result{}, nil
+		return nil, 0, nil, classifyarch.Result{}, nil
 	}
 
 	violations := evidencedto.ExtractViolations(archEv)
@@ -251,9 +250,9 @@ func (h *Handler) collectArchitecture(ctx context.Context, cmd Command, targets 
 		archEv = evidencedto.FilterNewViolations(archEv, classified.NewIDs)
 		archCount = len(classified.NewIDs)
 		*evidences = append(*evidences, *archEv)
-		return archEv, archCount, classified, nil
+		return archEv, archCount, archIDs, classified, nil
 	}
 
 	*evidences = append(*evidences, *archEv)
-	return archEv, archCount, classifyarch.Result{}, nil
+	return archEv, archCount, archIDs, classifyarch.Result{}, nil
 }

--- a/core/application/casefile/collectevidence/handler_test.go
+++ b/core/application/casefile/collectevidence/handler_test.go
@@ -202,6 +202,30 @@ func TestExecute_WithArchitectureFiltersToNewViolations(t *testing.T) {
 	assert.Equal(t, 0, result.ArchDelta.FixedCount)
 }
 
+func TestExecute_ArchIDsCarryAllCurrentViolationsForRatchet(t *testing.T) {
+	archEv := &evidencedto.Evidence{
+		Subtype: "architecture",
+		Architecture: &evidencedto.Architecture{
+			Violations: []evidencedto.Violation{
+				{Rule: "layer", SourcePkg: "api", TargetPkg: "domain", Message: "forbidden"},
+				{Rule: "layer", SourcePkg: "web", TargetPkg: "domain", Message: "forbidden"},
+				{Rule: "layer", SourcePkg: "ui", TargetPkg: "infra", Message: "forbidden"},
+			},
+		},
+	}
+
+	handler := newHandler(&fakeFindingsCollector{}, &fakeCoverageCollector{}, &fakeArchCollector{evidence: archEv, docs: [][]byte{[]byte("{}")}})
+
+	baselineArchIDs := []string{"layer:api:domain", "layer:web:domain"}
+	cmd, err := collectevidence.NewCommand("/ws", "//core/...", "core", "main", []string{"go"}, false, false, baselineArchIDs)
+	require.NoError(t, err)
+
+	result, err := handler.Execute(context.Background(), cmd)
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"layer:api:domain", "layer:web:domain", "layer:ui:infra"}, result.ArchIDs)
+}
+
 func TestExecute_WithArchitectureNoBaselineReportsAllNew(t *testing.T) {
 	archEv := &evidencedto.Evidence{
 		Subtype: "architecture",

--- a/core/infrastructure/platform/bazel/installer/install_test.go
+++ b/core/infrastructure/platform/bazel/installer/install_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/usegavel/gavel/core/infrastructure/platform/bazel/installer"
 )
 
-const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.5")`
+const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.6")`
 
 const (
 	gavelRegistryLine = "common --registry=https://gavelcode.github.io/registry"

--- a/core/infrastructure/platform/bazel/installer/installer.go
+++ b/core/infrastructure/platform/bazel/installer/installer.go
@@ -24,7 +24,7 @@ const moduleInclude = `include("//:.gavel/gavel.MODULE.bazel")`
 
 const GavelBazelrc = ".gavel/gavel.bazelrc"
 const GavelModule = ".gavel/gavel.MODULE.bazel"
-const gavelToolsVersion = "0.3.5"
+const gavelToolsVersion = "0.3.6"
 const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "` + gavelToolsVersion + `")`
 
 type Installer struct{}

--- a/examples/go-repo/MODULE.bazel
+++ b/examples/go-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.5")
+bazel_dep(name = "gavel_tools", version = "0.3.6")
 bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "gazelle", version = "0.50.0")
 

--- a/examples/java-repo/MODULE.bazel
+++ b/examples/java-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.5")
+bazel_dep(name = "gavel_tools", version = "0.3.6")
 bazel_dep(name = "rules_java", version = "9.1.0")
 
 include("//:.gavel/gavel.MODULE.bazel")

--- a/examples/python-repo/MODULE.bazel
+++ b/examples/python-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.5")
+bazel_dep(name = "gavel_tools", version = "0.3.6")
 bazel_dep(name = "rules_python", version = "1.7.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/examples/rust-fullstack-repo/MODULE.bazel
+++ b/examples/rust-fullstack-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.5")
+bazel_dep(name = "gavel_tools", version = "0.3.6")
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "aspect_rules_js", version = "3.0.3")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.8")


### PR DESCRIPTION
Restores Go architecture enforcement, which was silently a no-op. Two independent bugs, one masking the other.

## Bug 1 — detection (gavel_tools 0.3.6, already released)

The Go archtest aspect emitted **zero violations regardless of the source**. Under hermetic aspects it could not read `go.mod`, so it never recovered the module prefix needed to map imports to layers. Fixed upstream in gavel_tools ([PR #4](https://github.com/gavelcode/gavel-tools/pull/4), `v0.3.6`): the aspect derives the prefix from the target's `importpath` and passes it explicitly. This PR bumps the pin.

## Bug 2 — baseline ratchet (this repo)

Once detection works, `judge` **wiped the architecture baseline** every run. `collectArchitecture` filters the evidence to new-only violations before the handler extracts the arch IDs; when all current violations are already baselined, the filtered set is empty, so the ratchet treats the whole baseline as resolved and drops it — existing violations would resurface as "new" next run.

Fix: return the full current arch IDs from `collectArchitecture` and thread them to the ratchet, independent of the new-only filter used for the gate. The ratchet now intersects the baseline with **all** current violations (preserving existing debt) while still blocking on new violations only. New TDD test covers it.

## Verification

- **e2e (`examples/go-repo`, pinned 0.3.6):** the two real `userinterface → domain` / `→ infrastructure` violations are detected (`existing_violations_count: 2`), and the committed architecture baseline is **preserved** across runs.
- **Dogfood:** archtest across all 311 gavel Go targets → **0 violations** (Vernon-strict, genuinely clean). The bump does not break the `architecture max:0` gate.

## Changes

- Bug 2 fix + test in `collectevidence`.
- `gavel_tools` pin `0.3.5 → 0.3.6` in gavel's MODULE, the installer pin (lockstep via `version_test`), and all four example workspaces.