### PR TITLE
test(ci): assert the new-vs-baseline delta on a clean box

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,3 +217,33 @@ jobs:
           jq -e '([.projects[].rulings[] | select(.subtype == "tool_execution")]) as $te
                  | ($te | length > 0) and ($te | all(.passed == true))' result.json > /dev/null \
             || { echo "::error::an analyzer failed to run (tool_execution) in ${{ matrix.example }} on ${{ matrix.os }}"; exit 1; }
+
+      # New-vs-baseline proof: go-repo commits a fixture (baseline_probe.go) that
+      # is deliberately kept out of the baseline, so judge must report a known,
+      # exact delta across all three signals. Asserting *known values* — not just
+      # "zero new" — is what catches a silent regression (a stray exclude, an
+      # analyzer that stopped running): a zero would pass for the wrong reason.
+      # The linux+darwin legs together prove the verdict reproduces off the
+      # author's machine. These golden values change only when the fixture does;
+      # update them in the same PR.
+      - name: Assert the new-vs-baseline delta (fixture proof)
+        if: matrix.example == 'go-repo'
+        working-directory: examples/go-repo
+        run: |
+          fail() { echo "::error::$1 on ${{ matrix.os }}"; exit 1; }
+          jq -e '.projects[] as $p
+            | ($p.delta.new_count == 4)
+              and ([$p.findings[] | select(.status == "new")] | length == 4)
+              and ([$p.findings[] | select(.status == "new") | .file_path]
+                    | all(test("baseline_probe.go")))' result.json > /dev/null \
+            || fail "findings delta not reproducible (expected 4 new, all in baseline_probe.go)"
+          jq -e '.projects[] as $p
+            | ($p.delta.new_violations_count == 1)
+              and ([$p.violations[]? | select(.status == "new")
+                    | "\(.rule):\(.source_pkg):\(.target_pkg)"]
+                    == ["domain-imports-nothing:domain:infrastructure"])' result.json > /dev/null \
+            || fail "architecture delta not reproducible (expected 1 new domain->infrastructure violation)"
+          jq -e '[.projects[].coverage_by_file[]? | select(.file_path | test("baseline_probe.go"))] as $probe
+            | ($probe | length == 1) and ($probe[0].is_new == true) and ($probe[0].covered_lines == 0)' result.json > /dev/null \
+            || fail "coverage delta not reproducible (expected baseline_probe.go new and fully uncovered)"
+          echo "new-vs-baseline delta reproduced: 4 new findings, 1 new arch violation, 1 new uncovered file"

--- a/examples/go-repo/internal/domain/payment/BUILD.bazel
+++ b/examples/go-repo/internal/domain/payment/BUILD.bazel
@@ -3,13 +3,17 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "payment",
     srcs = [
+        "baseline_probe.go",
         "payment.go",
         "payment_repository.go",
         "payment_status.go",
     ],
     importpath = "github.com/example/go-repo/internal/domain/payment",
     visibility = ["//visibility:public"],
-    deps = ["//internal/domain/order"],
+    deps = [
+        "//internal/domain/order",
+        "//internal/infrastructure/persistence",
+    ],
 )
 
 go_test(

--- a/examples/go-repo/internal/domain/payment/baseline_probe.go
+++ b/examples/go-repo/internal/domain/payment/baseline_probe.go
@@ -1,0 +1,21 @@
+package payment
+
+// baseline_probe.go plants intentional defects (findings, architecture,
+// coverage) whose deltas the CI onboarding job asserts. Never baseline them.
+
+import "github.com/example/go-repo/internal/infrastructure/persistence"
+
+var ProbeRegistry = map[string]string{}
+
+func ProbeArchLeak() bool {
+	var repo *persistence.SQLiteOrderRepo
+	return repo == nil
+}
+
+func ProbeUncovered(values []int) int {
+	total := 0
+	for _, value := range values {
+		total += value
+	}
+	return total
+}


### PR DESCRIPTION
**Stacked on #13** (needs the arch fix + gavel_tools 0.3.6 to land first).

Closes the alpha→beta exit criterion: *a third party can reproduce the new-vs-baseline verdict in their own CI*. The onboarding job already proved analyzers **run** off the author's machine (`tool_execution`); this proves the **verdict** reproduces.

## How

`examples/go-repo` commits a fixture (`baseline_probe.go`) deliberately kept out of the baseline, so `judge` must report a known, exact delta across all three signals:

| Signal | Assertion |
|--------|-----------|
| Findings | `new_count == 4`, all in `baseline_probe.go` |
| Architecture | `new_violations_count == 1` = `domain-imports-nothing:domain:infrastructure` |
| Coverage | `baseline_probe.go` present, `is_new`, `covered_lines == 0` |

The onboarding job asserts these on the **linux + darwin** legs, so a mismatch on either box fails loudly.

## Why known values, not "zero new"

A silent regression — a stray exclude, an analyzer that stopped running — collapses the delta to zero, which a zero-based check passes for the wrong reason. Asserting a known nonzero catches it. (This is not hypothetical: the sibling PR fixes exactly such a silent-zero in Go architecture detection.)

Golden values change only when the fixture changes; they are updated in the same PR and reviewed in the diff.

## Verified

Ran the exact CI flow locally (`judge --json` → the three `jq` assertions) on the distributed binary: all three pass.