### PR TITLE
docs: document the gavel_tools upgrade path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ this index maps them. Start here and follow the links.
 ## Guides — get a task done
 
 * [CI integration](ci.md) — Running `gavel judge` and `gavel report` in CI pipelines.
+* [Upgrading gavel_tools](upgrading.md) — Moving a workspace between `gavel_tools` versions in 0.x, and why the pin tracks your gavel release.
 * [Server deployment](deployment.md) — Building, configuring, and running `gavel-server`.
 * [IDE integration](ide/vscode.md) — View findings inline: [VS Code](ide/vscode.md) · [IntelliJ IDEA](ide/intellij.md) · [MCP for agents](ide/mcp.md).
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,7 +47,8 @@ This generates:
 
 It also appends `try-import` and `include` lines to your `.bazelrc` and
 `MODULE.bazel`, and adds `common --registry=https://gavelcode.github.io/registry`
-to your `.bazelrc` so Bazel can resolve `gavel_tools`.
+to your `.bazelrc` so Bazel can resolve `gavel_tools`. To move that pin later,
+see [Upgrading gavel_tools](upgrading.md).
 
 ## 3. Verify
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,48 @@
+---
+title: Upgrading gavel_tools
+type: how-to
+description: How to move a workspace between gavel_tools versions during the 0.x series, and why the version is pinned to the gavel CLI you run.
+tags: [upgrade, versioning, gavel_tools, bazel]
+---
+
+# Upgrading gavel_tools
+
+`gavel_tools` is the Bazel module that provides the analyzer aspects. Your
+workspace pins it with one line in `MODULE.bazel`, written by `gavel init`:
+
+```starlark
+bazel_dep(name = "gavel_tools", version = "0.3.6")
+```
+
+## Why it is pinned to your gavel release
+
+During 0.x the aspect API is not stable, so a gavel release is validated
+against exactly **one** `gavel_tools` version — not a range. That pin is the
+source of truth: `installer.gavelToolsVersion` is what `gavel init` writes, and
+`installer/version_test.go` fails the build if it ever drifts from the
+`gavel_tools` version gavel itself depends on. Treat the two as one unit and do
+not mix an arbitrary `gavel_tools` with a gavel binary — the combination is
+untested. (This is also why BCR publication waits for 1.0: a stable aspect API
+is the pre-GA signal.)
+
+## Moving to a new version
+
+1. **Upgrade the gavel binary** ([releases](https://github.com/gavelcode/gavel/releases)).
+2. **Match the pin.** Set the `version` in your `MODULE.bazel` `gavel_tools`
+   `bazel_dep` to the one your new gavel writes. To read it without guessing,
+   run `gavel init` in a throwaway directory and copy the line it emits.
+3. Build once so Bazel updates `MODULE.bazel.lock` and resolves the module from
+   the gavel registry (already on your `.bazelrc` as
+   `--registry=https://gavelcode.github.io/registry`).
+
+`gavel init` is for first-time setup: it *adds* the pin when absent but does not
+rewrite an existing one, so re-running it in place will not migrate the version
+for you — edit the `version` string yourself.
+
+## Baselines survive the upgrade
+
+Committed baselines in `.gavel/baseline/` are keyed by fingerprint, not by tool
+version, so they carry across a `gavel_tools` bump. A version that changes an
+analyzer's output will surface as new-vs-baseline deltas on the next `judge` —
+which is the point: review them, then let the passing verdict ratchet the
+baseline forward. See [Baseline](baseline.md).


### PR DESCRIPTION
Closes blocker #4 of the alpha→beta list. The `gavel_tools` pin was decided and enforced, but the upgrade path was never written down for users.

Adds `docs/upgrading.md` (how-to) covering:

- **Why it's pinned to your gavel release** — the aspect API is unstable in 0.x, so a gavel binary is validated against exactly one `gavel_tools` version. `installer/version_test.go` keeps the pin gavel writes in lockstep with the version gavel itself depends on; don't mix arbitrary versions. (Also why BCR waits for 1.0.)
- **How to move versions** — upgrade the binary, match the `bazel_dep` version in `MODULE.bazel`, rebuild so the lock resolves from the gavel registry.
- **A sharp edge** — `gavel init` *adds* a missing pin but does not rewrite an existing one, so re-running it won't migrate the version; edit the `version` string yourself.
- **Baselines survive** the bump (keyed by fingerprint, not tool version); output changes surface as reviewable new-vs-baseline deltas.

Indexed under Guides and linked from the quickstart. Content points at the enforcing sources (`version_test`, the registry line) rather than restating version numbers.