### PR TITLE
fix(init): append lint filegroup to an existing root BUILD

### DIFF
--- a/core/infrastructure/platform/bazel/installer/install.go
+++ b/core/infrastructure/platform/bazel/installer/install.go
@@ -135,11 +135,22 @@ const lintConfigFilegroup = `filegroup(
     visibility = ["//visibility:public"],
 )`
 
+func rootBuildFile(root string) string {
+	bazelStyle := filepath.Join(root, "BUILD.bazel")
+	if _, err := os.Stat(bazelStyle); err == nil {
+		return bazelStyle
+	}
+	if _, err := os.Stat(filepath.Join(root, "BUILD")); err == nil {
+		return filepath.Join(root, "BUILD")
+	}
+	return bazelStyle
+}
+
 func installLintConfigFilegroup(root string) (bool, error) {
-	path := filepath.Join(root, "BUILD.bazel")
+	path := rootBuildFile(root)
 	existing, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
-		return false, fmt.Errorf("read BUILD.bazel: %w", err)
+		return false, fmt.Errorf("read %s: %w", filepath.Base(path), err)
 	}
 
 	if strings.Contains(string(existing), "gavel_lint_config") {

--- a/core/infrastructure/platform/bazel/installer/install_test.go
+++ b/core/infrastructure/platform/bazel/installer/install_test.go
@@ -114,6 +114,35 @@ func TestInstall_DoesNotDuplicateFilegroup(t *testing.T) {
 		"filegroup must not be duplicated on repeated installs")
 }
 
+func TestInstall_ExistingRootBuild_AppendsWithoutShadowing(t *testing.T) {
+	root := setupWorkspace(t, `module(name = "consumer-app", version = "1.0.0")`+"\n")
+	original := "config_setting(\n    name = \"fastbuild\",\n    values = {\"compilation_mode\": \"fastbuild\"},\n)\n"
+	require.NoError(t, os.WriteFile(filepath.Join(root, "BUILD"), []byte(original), 0o644))
+
+	_, err := installer.NewInstaller().Install(root, []string{"go"})
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(filepath.Join(root, "BUILD.bazel"))
+	assert.True(t, os.IsNotExist(statErr), "must not create a BUILD.bazel that shadows the existing root BUILD")
+
+	build := readFile(t, filepath.Join(root, "BUILD"))
+	assert.Contains(t, build, "gavel_lint_config", "filegroup must land in the existing root BUILD")
+	assert.Contains(t, build, "fastbuild", "the existing root package must be preserved")
+}
+
+func TestInstall_BothRootBuildFiles_PrefersBuildBazel(t *testing.T) {
+	root := setupWorkspace(t, `module(name = "consumer-app", version = "1.0.0")`+"\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "BUILD"), []byte("# legacy\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "BUILD.bazel"), []byte("# active\n"), 0o644))
+
+	_, err := installer.NewInstaller().Install(root, []string{"go"})
+	require.NoError(t, err)
+
+	assert.Contains(t, readFile(t, filepath.Join(root, "BUILD.bazel")), "gavel_lint_config",
+		"when both exist, Bazel uses BUILD.bazel, so the filegroup belongs there")
+	assert.NotContains(t, readFile(t, filepath.Join(root, "BUILD")), "gavel_lint_config")
+}
+
 func TestInstall_AddsGavelRegistry(t *testing.T) {
 	root := setupWorkspace(t, `module(name = "consumer-app", version = "1.0.0")`+"\n")
 


### PR DESCRIPTION
`gavel init` could **silently break a repo's build** during onboarding.

## The bug

The `gavel_lint_config` filegroup was written to `BUILD.bazel` unconditionally. Bazel gives `BUILD.bazel` precedence over `BUILD`, so on any repo whose root package is a plain `BUILD` file (a common convention — Google-style repos, many large monorepos), the generated `BUILD.bazel` **shadowed the real root package**. Everything the root defined — `config_setting`s, the `nogo` target, `npm_link_all_packages` — vanished, and every target referencing `//:...` failed to load. The whole repo became unbuildable after a single `gavel init`.

## The fix

Target the file that already defines the root package: `BUILD.bazel` when present, otherwise an existing `BUILD`, and only create `BUILD.bazel` when neither exists (so brand-new workspaces are unchanged).

## Found in the wild

Surfaced running gavel on **buildbuddy**, whose 350-line root `BUILD` was shadowed by a 19-line generated `BUILD.bazel`, cascading into `no such target '//:vet'` / `//:fastbuild` across the repo. Verified end-to-end: re-init now appends to `BUILD`, creates no shadowing `BUILD.bazel`, preserves the original, and the root package loads.

New tests cover the existing-`BUILD` case and the both-exist precedence (`BUILD.bazel` wins).