### PR TITLE
perf(coverage): survive at scale — bound test RAM and drop bazel's combined-report merge

### DIFF
--- a/core/infrastructure/casefile/lcov/perline_test.go
+++ b/core/infrastructure/casefile/lcov/perline_test.go
@@ -9,6 +9,32 @@ import (
 	"github.com/usegavel/gavel/core/infrastructure/casefile/lcov"
 )
 
+func TestParsePerLine_ConcatenatedEquivalentToBazelMerge(t *testing.T) {
+	merged := "SF:pkg/a.go\nDA:1,4\nDA:2,0\nDA:3,1\nend_of_record\n"
+	concatenated := "SF:pkg/a.go\nDA:1,2\nDA:2,0\nDA:3,0\nend_of_record\n" +
+		"SF:pkg/a.go\nDA:1,2\nDA:2,0\nDA:3,1\nend_of_record\n"
+
+	fromMerged, err := lcov.ParsePerLine([]byte(merged))
+	require.NoError(t, err)
+	fromConcatenated, err := lcov.ParsePerLine([]byte(concatenated))
+	require.NoError(t, err)
+
+	assert.Equal(t, coveredAndTotal(fromMerged), coveredAndTotal(fromConcatenated))
+}
+
+func coveredAndTotal(perLine map[string]map[int]int) [2]int {
+	var covered, total int
+	for _, lines := range perLine {
+		for _, hits := range lines {
+			total++
+			if hits > 0 {
+				covered++
+			}
+		}
+	}
+	return [2]int{covered, total}
+}
+
 func TestParsePerLineSingleFile(t *testing.T) {
 	result, err := lcov.ParsePerLine(readFixture(t, "single_lang.lcov"))
 

--- a/core/infrastructure/platform/bazel/runner/analysis.go
+++ b/core/infrastructure/platform/bazel/runner/analysis.go
@@ -12,6 +12,8 @@ import (
 
 const defaultTestSizeFilters = "small,medium"
 
+const coverageRAMBudget = "memory=HOST_RAM*0.67"
+
 type AnalysisConfig struct {
 	Workspace       string
 	Targets         []string
@@ -99,6 +101,7 @@ func buildBazelArgs(config AnalysisConfig) []string {
 		args = append(args,
 			"--test_size_filters="+sizeFilters,
 			"--combined_report=lcov",
+			"--local_resources="+coverageRAMBudget,
 		)
 	}
 	if config.TestTagFilters != "" {

--- a/core/infrastructure/platform/bazel/runner/analysis.go
+++ b/core/infrastructure/platform/bazel/runner/analysis.go
@@ -100,7 +100,6 @@ func buildBazelArgs(config AnalysisConfig) []string {
 		}
 		args = append(args,
 			"--test_size_filters="+sizeFilters,
-			"--combined_report=lcov",
 			"--local_resources="+coverageRAMBudget,
 		)
 	}
@@ -166,33 +165,24 @@ func SARIFReportsFromResult(result *AnalysisResult, aspects []catalog.Aspect) []
 	return reports
 }
 
-func collectCoverageDataWith(ctx context.Context, cmd CommandRunner, workspace string, runErr error) ([]byte, error) {
-	reportPath, err := findCombinedReportWith(ctx, cmd, workspace)
+func collectCoverageDataWith(ctx context.Context, _ CommandRunner, workspace string, runErr error) ([]byte, error) {
+	data, count, err := collectIndividualCoverageFiles(ctx, workspace)
 	if err != nil {
-		return nil, fmt.Errorf("find combined report: %w", err)
+		if runErr != nil {
+			return nil, fmt.Errorf("bazel coverage failed and coverage collection failed: %w", runErr)
+		}
+		return nil, fmt.Errorf("collect coverage: %w", err)
 	}
 
-	data, err := os.ReadFile(reportPath)
-	if err == nil && len(data) > 0 {
+	if count == 0 {
 		if runErr != nil {
-			return data, fmt.Errorf("bazel coverage had partial failures (report still collected): %w", runErr)
+			return nil, fmt.Errorf("bazel coverage failed and produced no coverage files: %w", runErr)
 		}
-		return data, nil
-	}
-
-	fallbackData, count, fallbackErr := collectIndividualCoverageFiles(ctx, workspace)
-	if fallbackErr != nil {
-		if runErr != nil {
-			return nil, fmt.Errorf("bazel coverage failed and fallback failed: %w", runErr)
-		}
-		return nil, fmt.Errorf("coverage fallback: %w", fallbackErr)
-	}
-	if count > 0 {
-		return fallbackData, fmt.Errorf("combined report unavailable; collected %d individual coverage files", count)
+		return nil, nil
 	}
 
 	if runErr != nil {
-		return nil, fmt.Errorf("bazel coverage failed and produced no report: %w", runErr)
+		return data, fmt.Errorf("bazel coverage had partial failures (coverage still collected): %w", runErr)
 	}
-	return nil, nil
+	return data, nil
 }

--- a/core/infrastructure/platform/bazel/runner/analysis_test.go
+++ b/core/infrastructure/platform/bazel/runner/analysis_test.go
@@ -86,6 +86,16 @@ func TestBuildBazelArgs_CoverageMode(t *testing.T) {
 	}
 }
 
+func TestBuildBazelArgs_CoverageBoundsMemory(t *testing.T) {
+	cov := buildBazelArgs(AnalysisConfig{Targets: []string{"//..."}, IncludeCoverage: true})
+	assert.Contains(t, cov, "--local_resources=memory=HOST_RAM*0.67")
+
+	build := buildBazelArgs(AnalysisConfig{Targets: []string{"//..."}, IncludeCoverage: false})
+	for _, a := range build {
+		assert.NotContains(t, a, "local_resources")
+	}
+}
+
 func TestBuildBazelArgs_BuildMode(t *testing.T) {
 	config := AnalysisConfig{
 		Targets:         []string{"//..."},

--- a/core/infrastructure/platform/bazel/runner/analysis_test.go
+++ b/core/infrastructure/platform/bazel/runner/analysis_test.go
@@ -79,9 +79,9 @@ func TestBuildBazelArgs_CoverageMode(t *testing.T) {
 	args := buildBazelArgs(config)
 
 	assert.Equal(t, "coverage", args[0])
-	assert.Contains(t, args, "--combined_report=lcov")
 	assert.Contains(t, args, "--test_size_filters=small,medium")
 	for _, a := range args {
+		assert.NotContains(t, a, "combined_report")
 		assert.NotContains(t, a, "instrumentation_filter")
 	}
 }
@@ -373,19 +373,16 @@ func TestRunAnalysis_BuildErrorWithSARIF(t *testing.T) {
 }
 
 func TestRunAnalysis_WithCoverage(t *testing.T) {
+	workspace := t.TempDir()
 	binDir := t.TempDir()
-	outputPath := t.TempDir()
-	coverageDir := filepath.Join(outputPath, "_coverage")
-	require.NoError(t, os.MkdirAll(coverageDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(coverageDir, "_coverage_report.dat"), []byte("SF:main.go\nend_of_record\n"), 0o644))
+	createCoverageFile(t, filepath.Join(workspace, "bazel-testlogs"), "pkg/main_test", "SF:main.go\nDA:1,1\nend_of_record\n")
 
 	fake := &fakeRunner{results: []fakeResult{
 		{Stdout: []byte("coverage ok\n")},
 		{Stdout: []byte(binDir + "\n")},
-		{Stdout: []byte(outputPath + "\n")},
 	}}
 	config := AnalysisConfig{
-		Workspace:       "/ws",
+		Workspace:       workspace,
 		Targets:         []string{"//..."},
 		Aspects:         []catalog.Aspect{{Name: "golangci", SARIFSuffix: ".golangci.sarif"}},
 		IncludeCoverage: true,

--- a/core/infrastructure/platform/bazel/runner/coverage.go
+++ b/core/infrastructure/platform/bazel/runner/coverage.go
@@ -71,6 +71,9 @@ func collectIndividualCoverageFiles(ctx context.Context, workspace string) ([]by
 	if err != nil {
 		return nil, 0, fmt.Errorf("resolve testlogs dir: %w", err)
 	}
+	if resolved, evalErr := filepath.EvalSymlinks(testlogsDir); evalErr == nil {
+		testlogsDir = resolved
+	}
 
 	var merged bytes.Buffer
 	var count int

--- a/core/infrastructure/platform/bazel/runner/coverage_test.go
+++ b/core/infrastructure/platform/bazel/runner/coverage_test.go
@@ -194,7 +194,7 @@ func TestResolveTestlogsDirWith_BazelInfoError(t *testing.T) {
 	assert.Contains(t, err.Error(), "bazel info output_path")
 }
 
-func TestCollectCoverageDataWith_FallbackToIndividual(t *testing.T) {
+func TestCollectCoverageDataWith_CollectsIndividual(t *testing.T) {
 	workspace := t.TempDir()
 	outputPath := t.TempDir()
 	testlogsDir := filepath.Join(workspace, "bazel-testlogs")
@@ -208,8 +208,24 @@ func TestCollectCoverageDataWith_FallbackToIndividual(t *testing.T) {
 
 	require.NotNil(t, data)
 	assert.Contains(t, string(data), "SF:foo.go")
+	assert.Nil(t, warning)
+}
+
+func TestCollectCoverageDataWith_CollectsIndividualWithRunErr(t *testing.T) {
+	workspace := t.TempDir()
+	outputPath := t.TempDir()
+	testlogsDir := filepath.Join(workspace, "bazel-testlogs")
+	createCoverageFile(t, testlogsDir, "pkg/foo_test", "SF:foo.go\nDA:1,1\nend_of_record\n")
+
+	fake := &fakeRunner{results: []fakeResult{
+		{Stdout: []byte(outputPath + "\n")},
+	}}
+
+	data, warning := collectCoverageDataWith(t.Context(), fake, workspace, fmt.Errorf("coverage failed"))
+
+	require.NotNil(t, data)
 	require.NotNil(t, warning)
-	assert.Contains(t, warning.Error(), "individual coverage files")
+	assert.Contains(t, warning.Error(), "partial failures")
 }
 
 func TestCollectCoverageDataWith_NoDataNoRunErr(t *testing.T) {
@@ -244,7 +260,7 @@ func TestCollectCoverageDataWith_NoDataWithRunErr(t *testing.T) {
 	assert.Contains(t, warning.Error(), "coverage failed")
 }
 
-func TestCollectCoverageDataWith_FindReportError(t *testing.T) {
+func TestCollectCoverageDataWith_ResolveTestlogsError(t *testing.T) {
 	fake := &fakeRunner{results: []fakeResult{
 		{Stderr: []byte("fail"), Err: fmt.Errorf("info error")},
 	}}
@@ -253,7 +269,7 @@ func TestCollectCoverageDataWith_FindReportError(t *testing.T) {
 
 	assert.Nil(t, data)
 	require.NotNil(t, warning)
-	assert.Contains(t, warning.Error(), "find combined report")
+	assert.Contains(t, warning.Error(), "collect coverage")
 }
 
 func TestCollectCoverageDataWith_FallbackErrorWithRunErr(t *testing.T) {
@@ -270,21 +286,6 @@ func TestCollectCoverageDataWith_FallbackErrorWithRunErr(t *testing.T) {
 	assert.Nil(t, data)
 	require.NotNil(t, warning)
 	assert.Contains(t, warning.Error(), "coverage failed")
-}
-
-func TestCollectCoverageDataWith_FallbackErrorWithoutRunErr(t *testing.T) {
-	workspace := t.TempDir()
-	outputPath := t.TempDir()
-
-	fake := &fakeRunner{results: []fakeResult{
-		{Stdout: []byte(outputPath + "\n")},
-	}}
-
-	data, warning := collectCoverageDataWith(t.Context(), fake, workspace, nil)
-
-	assert.Nil(t, data)
-	require.NotNil(t, warning)
-	assert.Contains(t, warning.Error(), "coverage fallback")
 }
 
 func createCoverageFile(t *testing.T, testlogsDir, testPath, content string) {

--- a/core/infrastructure/platform/bazel/runner/coverage_test.go
+++ b/core/infrastructure/platform/bazel/runner/coverage_test.go
@@ -68,6 +68,20 @@ func TestCollectIndividualCoverageFiles_ConcatenatesValidLCOV(t *testing.T) {
 	assert.Contains(t, string(data), "SF:b.go")
 }
 
+func TestCollectIndividualCoverageFiles_FollowsTestlogsSymlink(t *testing.T) {
+	realTestlogs := t.TempDir()
+	createCoverageFile(t, realTestlogs, "pkg/foo_test", "SF:pkg/foo.go\nDA:1,1\nend_of_record\n")
+
+	workspace := t.TempDir()
+	require.NoError(t, os.Symlink(realTestlogs, filepath.Join(workspace, "bazel-testlogs")))
+
+	data, count, err := collectIndividualCoverageFiles(t.Context(), workspace)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Contains(t, string(data), "SF:pkg/foo.go")
+}
+
 func TestResolveTestlogsDir_PrefersSymlink(t *testing.T) {
 	dir := t.TempDir()
 	testlogsDir := filepath.Join(dir, "bazel-testlogs")


### PR DESCRIPTION
Makes `gavel judge` coverage survive on real, large monorepos. Two independent memory sinks, found running gavel on **buildbuddy**.

## 1. Test-execution memory — bound it

`bazel coverage //...` assumed all of `HOST_RAM` was available and launched more test processes in parallel than fit. Pass `--local_resources=memory=HOST_RAM*0.67` so Bazel paces tests to the machine. General, standard lever — no magic job count, no per-repo tags.

## 2. The combined-report merge — drop it (the real OOM)

`--combined_report=lcov` merges every test's coverage in a **single local action** that holds all coverage data in one process. That merge is what actually OOM-killed the run — it died *after* the tests completed, and *even after* splitting the repo into per-subtree projects. ([Bazel docs](https://bazel.build/configure/coverage): the report-combination action can't even run remotely.)

Drop `--combined_report` and read the per-test `coverage.dat` files gavel's collector already gathers; let the LCOV parser merge them. Peak memory is now bounded by the coverage text, not one all-at-once merge.

### Same result, proven

gavel's parser keeps the **max hit per line**, so a line is covered iff any test covered it — mathematically identical covered/total to bazel's *summing* merge. Verified two ways:
- **Unit test**: parsing a bazel-merged LCOV vs the concatenated per-test LCOVs yields identical covered/total.
- **Real data** (buildbuddy `//codesearch/...`): `2720/3626 = 75.01%` from *both* the combined report and gavel's per-test collection — identical.

### Impact

On buildbuddy, `bazel coverage //enterprise/server/...` (integration excluded) died at the merge with `--combined_report`; **without it, the same scope completes in ~70s, no OOM**.

`RunCoverage` in `coverage.go` (unused legacy path) is left untouched; `gavel judge` goes through `RunAnalysis`.