### PR TITLE
build(deps): bump gavel_tools to 0.3.7

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ bazel_dep(name = "aspect_rules_ts", version = "3.8.8")
 bazel_dep(name = "aspect_rules_esbuild", version = "0.25.1")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
 bazel_dep(name = "rules_rust", version = "0.70.0")
-bazel_dep(name = "gavel_tools", version = "0.3.6")
+bazel_dep(name = "gavel_tools", version = "0.3.7")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.25.7")

--- a/core/infrastructure/platform/bazel/installer/install_test.go
+++ b/core/infrastructure/platform/bazel/installer/install_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/usegavel/gavel/core/infrastructure/platform/bazel/installer"
 )
 
-const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.6")`
+const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.7")`
 
 const (
 	gavelRegistryLine = "common --registry=https://gavelcode.github.io/registry"

--- a/core/infrastructure/platform/bazel/installer/installer.go
+++ b/core/infrastructure/platform/bazel/installer/installer.go
@@ -24,7 +24,7 @@ const moduleInclude = `include("//:.gavel/gavel.MODULE.bazel")`
 
 const GavelBazelrc = ".gavel/gavel.bazelrc"
 const GavelModule = ".gavel/gavel.MODULE.bazel"
-const gavelToolsVersion = "0.3.6"
+const gavelToolsVersion = "0.3.7"
 const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "` + gavelToolsVersion + `")`
 
 type Installer struct{}

--- a/examples/go-repo/MODULE.bazel
+++ b/examples/go-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.6")
+bazel_dep(name = "gavel_tools", version = "0.3.7")
 bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "gazelle", version = "0.50.0")
 

--- a/examples/java-repo/MODULE.bazel
+++ b/examples/java-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.6")
+bazel_dep(name = "gavel_tools", version = "0.3.7")
 bazel_dep(name = "rules_java", version = "9.1.0")
 
 include("//:.gavel/gavel.MODULE.bazel")

--- a/examples/python-repo/MODULE.bazel
+++ b/examples/python-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.6")
+bazel_dep(name = "gavel_tools", version = "0.3.7")
 bazel_dep(name = "rules_python", version = "1.7.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/examples/rust-fullstack-repo/MODULE.bazel
+++ b/examples/rust-fullstack-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.6")
+bazel_dep(name = "gavel_tools", version = "0.3.7")
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "aspect_rules_js", version = "3.0.3")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.8")


### PR DESCRIPTION
Bumps `gavel_tools` `0.3.6 → 0.3.7`, which fixes the golangci aspect on repos using Bazel **config transitions** (cross-compiled `go_binary`: `goos`/`goarch`/`pure`/`static`).

Upstream: [gavel-tools#5](https://github.com/gavelcode/gavel-tools/pull/5). The static packages driver now sources the exported stdlib from the `GoStdLib` provider instead of the empty `go_sdk.libs`, so stdlib types resolve and golangci-lint analyzes instead of cascading `typecheck` errors. Validated on buildbuddy (43 typecheck → 3) with no regression on the examples.

Bumps the pin in gavel's MODULE, the installer pin (lockstep via `version_test`), and all four example workspaces.