### PR TITLE
fix(installer): order BCR before the gavel registry in .bazelrc

### DIFF
--- a/core/infrastructure/platform/bazel/installer/install.go
+++ b/core/infrastructure/platform/bazel/installer/install.go
@@ -175,7 +175,11 @@ const (
 	registryLineCount = 2
 )
 
-// Bazel drops its implicit BCR default once any --registry is set, so both must be listed.
+// Bazel drops its implicit BCR default once any --registry is set, so both must
+// be listed. Registries are consulted in order, so BCR goes first: the consumer's
+// own modules keep resolving from BCR with the checksums already in their lockfile,
+// and the gavel registry serves only as the fallback for gavel_tools. Listing gavel
+// first re-resolves every module through it and breaks repos with lockfile_mode=error.
 func ensureRegistryLines(root string) (bool, error) {
 	path := filepath.Join(root, ".bazelrc")
 	existing, err := os.ReadFile(path)
@@ -185,11 +189,11 @@ func ensureRegistryLines(root string) (bool, error) {
 	content := string(existing)
 
 	missing := make([]string, 0, registryLineCount)
-	if !strings.Contains(content, gavelRegistryLine) {
-		missing = append(missing, gavelRegistryLine)
-	}
 	if !strings.Contains(content, bcrRegistryLine) {
 		missing = append(missing, bcrRegistryLine)
+	}
+	if !strings.Contains(content, gavelRegistryLine) {
+		missing = append(missing, gavelRegistryLine)
 	}
 	if len(missing) == 0 {
 		return false, nil

--- a/core/infrastructure/platform/bazel/installer/install_test.go
+++ b/core/infrastructure/platform/bazel/installer/install_test.go
@@ -165,6 +165,21 @@ func TestInstall_KeepsBcrAlongsideGavelRegistry(t *testing.T) {
 		"declaring any registry drops Bazel's BCR default, so BCR must be added explicitly")
 }
 
+func TestInstall_BcrRegistryOrderedBeforeGavel(t *testing.T) {
+	root := setupWorkspace(t, `module(name = "consumer-app", version = "1.0.0")`+"\n")
+
+	_, err := installer.NewInstaller().Install(root, []string{"go"})
+	require.NoError(t, err)
+
+	bazelrc := readFile(t, filepath.Join(root, ".bazelrc"))
+	bcrAt := strings.Index(bazelrc, bcrRegistryLine)
+	gavelAt := strings.Index(bazelrc, gavelRegistryLine)
+	require.NotEqual(t, -1, bcrAt)
+	require.NotEqual(t, -1, gavelAt)
+	assert.Less(t, bcrAt, gavelAt,
+		"BCR must precede the gavel registry so the consumer's own BCR modules keep resolving from BCR with unchanged checksums; listing gavel first re-resolves every module through it and breaks repos with lockfile_mode=error")
+}
+
 func TestInstall_ExistingBcr_NotDuplicated(t *testing.T) {
 	root := setupWorkspace(t, `module(name = "consumer-app", version = "1.0.0")`+"\n")
 	require.NoError(t, os.WriteFile(filepath.Join(root, ".bazelrc"), []byte(bcrRegistryLine+"\n"), 0o644))


### PR DESCRIPTION
## Problem

`gavel init` wrote its registry line **ahead of** BCR:

```
common --registry=https://gavelcode.github.io/registry   ← gavel, first
common --registry=https://bcr.bazel.build                ← BCR, second
```

Declaring any `--registry` drops Bazel's implicit BCR default, and registries are consulted **in order**. Listing gavel first makes Bazel re-resolve *every* module — including the consumer's own dependencies — through the gavel registry first. In a repo with `lockfile_mode=error`, that shifts the registry recorded per module, the existing `MODULE.bazel.lock` no longer validates, and the very first `gavel judge` fails at main-repo mapping **before any build runs**:

```
ERROR: Missing checksum for registry file .../gavelcode/registry/modules/gperf/3.1/MODULE.bazel
not permitted with --lockfile_mode=error.
```

Found while running `gavel judge` against the [monogon](https://github.com/monogon-dev/monogon) monorepo — its own `gperf` dep tripped the checksum mismatch. Strict lockfiles are the norm in serious monorepos, so this blocks exactly the adopters we most want.

## Fix

Emit BCR **before** the gavel registry. The consumer's modules keep resolving from BCR with the checksums already in their lockfile; the gavel registry stays as the fallback that serves only `gavel_tools`. The existing-BCR path already appended gavel last, so this only reorders the both-missing case.

## Test

`TestInstall_BcrRegistryOrderedBeforeGavel` asserts BCR precedes the gavel registry in the generated `.bazelrc`. Red before the fix (gavel at index 0, BCR at 55), green after. All existing installer tests still pass.