### PR TITLE
feat(judge): surface tools that analyzed zero targets instead of passing silently

### DIFF
--- a/core/application/casefile/collectevidence/handler.go
+++ b/core/application/casefile/collectevidence/handler.go
@@ -76,7 +76,7 @@ func (h *Handler) Execute(ctx context.Context, cmd Command) (Result, error) {
 		}
 	}
 
-	findingsEvidences, rawSARIF, buildWarning, err := h.collectFindings(ctx, cmd, targets)
+	findingsEvidences, rawSARIF, buildWarning, unanalyzedTools, err := h.collectFindings(ctx, cmd, targets)
 	if err != nil {
 		return Result{}, fmt.Errorf("findings: %w", err)
 	}
@@ -148,6 +148,7 @@ func (h *Handler) Execute(ctx context.Context, cmd Command) (Result, error) {
 		ArchIDs:         archIDs,
 		ArchDelta:       archDelta,
 		BuildWarning:    buildWarning,
+		UnanalyzedTools: unanalyzedTools,
 	}, nil
 }
 
@@ -174,9 +175,9 @@ func (h *Handler) appendToolExecutionEvidence(evidences []evidencedto.Evidence, 
 	})
 }
 
-func (h *Handler) collectFindings(ctx context.Context, cmd Command, targets []string) ([]evidencedto.Evidence, []RawFile, string, error) {
+func (h *Handler) collectFindings(ctx context.Context, cmd Command, targets []string) ([]evidencedto.Evidence, []RawFile, string, []string, error) {
 	if h.findings == nil {
-		return nil, nil, "", nil
+		return nil, nil, "", nil, nil
 	}
 	return h.findings.CollectFindings(ctx, cmd.Workspace(), targets, cmd.ToolSelection())
 }

--- a/core/application/casefile/collectevidence/handler_test.go
+++ b/core/application/casefile/collectevidence/handler_test.go
@@ -19,14 +19,15 @@ import (
 )
 
 type fakeFindingsCollector struct {
-	evidences    []evidencedto.Evidence
-	rawFiles     []collectevidence.RawFile
-	buildWarning string
-	err          error
+	evidences       []evidencedto.Evidence
+	rawFiles        []collectevidence.RawFile
+	buildWarning    string
+	unanalyzedTools []string
+	err             error
 }
 
-func (f *fakeFindingsCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, error) {
-	return f.evidences, f.rawFiles, f.buildWarning, f.err
+func (f *fakeFindingsCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
+	return f.evidences, f.rawFiles, f.buildWarning, f.unanalyzedTools, f.err
 }
 
 type fakeCoverageCollector struct {
@@ -63,9 +64,9 @@ type capturingFindingsCollector struct {
 	rawFiles        []collectevidence.RawFile
 }
 
-func (c *capturingFindingsCollector) CollectFindings(_ context.Context, _ string, targets []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, error) {
+func (c *capturingFindingsCollector) CollectFindings(_ context.Context, _ string, targets []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	c.capturedTargets = targets
-	return c.evidences, c.rawFiles, "", nil
+	return c.evidences, c.rawFiles, "", nil, nil
 }
 
 func newHandler(findings *fakeFindingsCollector, coverage *fakeCoverageCollector, arch *fakeArchCollector) *collectevidence.Handler {
@@ -119,6 +120,23 @@ func TestExecute_PropagatesBuildWarning(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "bazel build had failures", result.BuildWarning)
+}
+
+func TestExecute_PropagatesUnanalyzedTools(t *testing.T) {
+	findings := &fakeFindingsCollector{
+		evidences:       []evidencedto.Evidence{{Subtype: "code_quality"}},
+		unanalyzedTools: []string{"typescript_eslint_submission_aspect"},
+	}
+
+	handler := newHandler(findings, &fakeCoverageCollector{}, &fakeArchCollector{})
+
+	cmd, err := collectevidence.NewCommand("/ws", "//core/...", "core", "main", []string{"go"}, true, false, nil)
+	require.NoError(t, err)
+
+	result, err := handler.Execute(context.Background(), cmd)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"typescript_eslint_submission_aspect"}, result.UnanalyzedTools)
 }
 
 func TestExecute_NoBuildWarning_WhenCleanBuild(t *testing.T) {

--- a/core/application/casefile/collectevidence/ports.go
+++ b/core/application/casefile/collectevidence/ports.go
@@ -7,7 +7,7 @@ import (
 )
 
 type FindingsCollector interface {
-	CollectFindings(ctx context.Context, workspace string, targets []string, selection map[string][]string) ([]evidencedto.Evidence, []RawFile, string, error)
+	CollectFindings(ctx context.Context, workspace string, targets []string, selection map[string][]string) ([]evidencedto.Evidence, []RawFile, string, []string, error)
 }
 
 type CoverageCollector interface {

--- a/core/application/casefile/collectevidence/result.go
+++ b/core/application/casefile/collectevidence/result.go
@@ -21,6 +21,7 @@ type Result struct {
 	ArchIDs         []string
 	ArchDelta       classifyarch.Result
 	BuildWarning    string
+	UnanalyzedTools []string
 }
 
 type RawFile struct {

--- a/core/infrastructure/platform/bazel/collector/findings.go
+++ b/core/infrastructure/platform/bazel/collector/findings.go
@@ -28,10 +28,10 @@ func NewBazelFindingsCollector(r AnalysisRunner, p FindingsParser) *BazelFinding
 	return &BazelFindingsCollector{runner: r, parser: p}
 }
 
-func (c *BazelFindingsCollector) CollectFindings(ctx context.Context, workspace string, targets []string, selection map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, error) {
+func (c *BazelFindingsCollector) CollectFindings(ctx context.Context, workspace string, targets []string, selection map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	selected, err := catalog.SelectedAspects(selection)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, "", nil, err
 	}
 	lintAspects := make([]catalog.Aspect, 0, len(selected))
 	for _, aspect := range selected {
@@ -40,7 +40,7 @@ func (c *BazelFindingsCollector) CollectFindings(ctx context.Context, workspace 
 		}
 	}
 	if len(lintAspects) == 0 {
-		return nil, nil, "", nil
+		return nil, nil, "", nil, nil
 	}
 
 	config := runner.AnalysisConfig{
@@ -51,7 +51,7 @@ func (c *BazelFindingsCollector) CollectFindings(ctx context.Context, workspace 
 
 	result, err := c.runner.RunAnalysis(ctx, config)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("run analysis: %w", err)
+		return nil, nil, "", nil, fmt.Errorf("run analysis: %w", err)
 	}
 
 	reports := runner.SARIFReportsFromResult(result, lintAspects)
@@ -61,11 +61,11 @@ func (c *BazelFindingsCollector) CollectFindings(ctx context.Context, workspace 
 	for _, report := range reports {
 		cmd, err := ingestfind.NewCommand(report.Data, "sarif", report.Source, "code_quality")
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, "", nil, err
 		}
 		res, err := c.parser.Execute(ctx, cmd)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, "", nil, err
 		}
 		evidences = append(evidences, res.Evidence)
 		rawFiles = append(rawFiles, collectevidence.RawFile{
@@ -79,5 +79,5 @@ func (c *BazelFindingsCollector) CollectFindings(ctx context.Context, workspace 
 	if result.BuildWarning != nil {
 		buildWarning = result.BuildWarning.Error()
 	}
-	return evidences, rawFiles, buildWarning, nil
+	return evidences, rawFiles, buildWarning, runner.ToolsWithoutSubmissions(result, lintAspects), nil
 }

--- a/core/infrastructure/platform/bazel/collector/findings_test.go
+++ b/core/infrastructure/platform/bazel/collector/findings_test.go
@@ -19,12 +19,14 @@ func TestBazelFindingsCollector_NoReports_ReturnsEmpty(t *testing.T) {
 	parser := &fakeFindingsParser{}
 	c := collector.NewBazelFindingsCollector(runner, parser)
 
-	evidences, rawFiles, buildWarning, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	evidences, rawFiles, buildWarning, unanalyzed, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
 
 	require.NoError(t, err)
 	assert.Empty(t, evidences)
 	assert.Empty(t, rawFiles)
 	assert.Empty(t, buildWarning)
+	assert.NotEmpty(t, unanalyzed,
+		"a configured tool that produced no SARIF must be reported as having analyzed nothing, not silently omitted")
 }
 
 func TestBazelFindingsCollector_ParsesReports(t *testing.T) {
@@ -33,7 +35,7 @@ func TestBazelFindingsCollector_ParsesReports(t *testing.T) {
 	parser := &fakeFindingsParser{returnEmpty: true}
 	c := collector.NewBazelFindingsCollector(runner, parser)
 
-	evidences, rawFiles, buildWarning, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	evidences, rawFiles, buildWarning, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
 
 	require.NoError(t, err)
 	assert.Len(t, evidences, 1)
@@ -47,7 +49,7 @@ func TestBazelFindingsCollector_NoAspectsForEmptySelection(t *testing.T) {
 	parser := &fakeFindingsParser{}
 	c := collector.NewBazelFindingsCollector(r, parser)
 
-	evidences, rawFiles, buildWarning, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{})
+	evidences, rawFiles, buildWarning, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{})
 
 	require.NoError(t, err)
 	assert.Nil(t, evidences)
@@ -60,7 +62,7 @@ func TestBazelFindingsCollector_RunnerError(t *testing.T) {
 	parser := &fakeFindingsParser{}
 	c := collector.NewBazelFindingsCollector(r, parser)
 
-	_, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	_, _, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "run analysis")
@@ -72,7 +74,7 @@ func TestBazelFindingsCollector_ParserError(t *testing.T) {
 	parser := &fakeFindingsParser{err: fmt.Errorf("parse failed")}
 	c := collector.NewBazelFindingsCollector(r, parser)
 
-	_, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	_, _, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse failed")
@@ -83,7 +85,7 @@ func TestBazelFindingsCollector_EmptySARIFData(t *testing.T) {
 	parser := &fakeFindingsParser{}
 	c := collector.NewBazelFindingsCollector(r, parser)
 
-	_, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	_, _, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
 
 	require.Error(t, err)
 }
@@ -97,7 +99,7 @@ func TestBazelFindingsCollector_PropagatesBuildWarning(t *testing.T) {
 	parser := &fakeFindingsParser{returnEmpty: true}
 	c := collector.NewBazelFindingsCollector(runner, parser)
 
-	evidences, rawFiles, buildWarning, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	evidences, rawFiles, buildWarning, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
 
 	require.NoError(t, err)
 	assert.Len(t, evidences, 1)

--- a/core/infrastructure/platform/bazel/runner/analysis.go
+++ b/core/infrastructure/platform/bazel/runner/analysis.go
@@ -165,6 +165,16 @@ func SARIFReportsFromResult(result *AnalysisResult, aspects []catalog.Aspect) []
 	return reports
 }
 
+func ToolsWithoutSubmissions(result *AnalysisResult, aspects []catalog.Aspect) []string {
+	var out []string
+	for _, asp := range aspects {
+		if len(result.SARIFFiles[asp.Name]) == 0 {
+			out = append(out, asp.Name)
+		}
+	}
+	return out
+}
+
 func collectCoverageDataWith(ctx context.Context, _ CommandRunner, workspace string, runErr error) ([]byte, error) {
 	data, count, err := collectIndividualCoverageFiles(ctx, workspace)
 	if err != nil {

--- a/core/infrastructure/platform/bazel/runner/analysis_test.go
+++ b/core/infrastructure/platform/bazel/runner/analysis_test.go
@@ -13,6 +13,35 @@ import (
 	"github.com/usegavel/gavel/core/infrastructure/platform/bazel/catalog"
 )
 
+func TestToolsWithoutSubmissions_FlagsConfiguredAspectThatProducedNoSarif(t *testing.T) {
+	result := &AnalysisResult{
+		SARIFFiles: map[string][][]byte{
+			"clippy": {[]byte("{}")},
+		},
+	}
+	aspects := []catalog.Aspect{
+		{Name: "clippy"},
+		{Name: "eslint"},
+	}
+
+	got := ToolsWithoutSubmissions(result, aspects)
+
+	assert.Equal(t, []string{"eslint"}, got,
+		"an enabled aspect that emitted no SARIF attached to zero targets; surfacing it keeps a 0-findings verdict from silently implying the tool ran")
+}
+
+func TestToolsWithoutSubmissions_EmptyWhenEveryAspectProducedSarif(t *testing.T) {
+	result := &AnalysisResult{
+		SARIFFiles: map[string][][]byte{
+			"clippy": {[]byte("{}")},
+			"eslint": {[]byte("{}")},
+		},
+	}
+	aspects := []catalog.Aspect{{Name: "clippy"}, {Name: "eslint"}}
+
+	assert.Empty(t, ToolsWithoutSubmissions(result, aspects))
+}
+
 func TestBuildBazelArgs_TargetsAfterOptionsMarker(t *testing.T) {
 	config := AnalysisConfig{
 		Targets: []string{"//core/...", "-//core/gen/..."},

--- a/core/userinterface/cli/judge/judge.go
+++ b/core/userinterface/cli/judge/judge.go
@@ -301,6 +301,11 @@ func emitResults(writer io.Writer, results []pipeline.Result, opts Options, star
 				return err
 			}
 		}
+		if len(projResult.UnanalyzedTools) > 0 {
+			if _, err := fmt.Fprint(writer, ui.MissingTargetsWarning(projResult.Name, projResult.UnanalyzedTools)); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/core/userinterface/cli/judge/judge_test.go
+++ b/core/userinterface/cli/judge/judge_test.go
@@ -274,12 +274,12 @@ func (f fakeFinder) LoadFromConfig(_ string) (gavelspacemodel.Gavelspace, []proj
 
 type stubFindingsCollector struct{}
 
-func (s stubFindingsCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, error) {
+func (s stubFindingsCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	return []evidencedto.Evidence{{
 		Subtype:     "code_quality",
 		Source:      "empty.sarif",
 		CollectedAt: time.Date(2025, 6, 20, 10, 0, 0, 0, time.UTC),
-	}}, nil, "", nil
+	}}, nil, "", nil, nil
 }
 
 type stubTargetResolver struct {
@@ -680,16 +680,16 @@ type findingsCollectorWithData struct {
 	parser   *ingestfind.Handler
 }
 
-func (f *findingsCollectorWithData) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, error) {
+func (f *findingsCollectorWithData) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	cmd, err := ingestfind.NewCommand([]byte(`{"runs":[]}`), "sarif", "test.sarif", "code_quality")
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, "", nil, err
 	}
 	res, err := f.parser.Execute(context.Background(), cmd)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, "", nil, err
 	}
-	return []evidencedto.Evidence{res.Evidence}, nil, "", nil
+	return []evidencedto.Evidence{res.Evidence}, nil, "", nil, nil
 }
 
 func mustFP(t *testing.T, value string) finding.FingerprintID {
@@ -866,8 +866,8 @@ type failingCollector struct {
 	err error
 }
 
-func (f *failingCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, error) {
-	return nil, nil, "", f.err
+func (f *failingCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
+	return nil, nil, "", nil, f.err
 }
 
 func TestRun_CollectEvidenceError(t *testing.T) {
@@ -897,12 +897,12 @@ func TestRun_CollectEvidenceError(t *testing.T) {
 
 type buildWarningCollector struct{}
 
-func (b *buildWarningCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, error) {
+func (b *buildWarningCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	return []evidencedto.Evidence{{
 		Subtype:     "code_quality",
 		Source:      "empty.sarif",
 		CollectedAt: time.Date(2025, 6, 20, 10, 0, 0, 0, time.UTC),
-	}}, nil, "partial build failure", nil
+	}}, nil, "partial build failure", nil, nil
 }
 
 func TestRun_BuildWarning(t *testing.T) {

--- a/core/userinterface/cli/judge/output/json/json.go
+++ b/core/userinterface/cli/judge/output/json/json.go
@@ -80,6 +80,7 @@ type projectDTO struct {
 	Violations             []violationDTO     `json:"violations,omitempty"`
 	Delta                  *deltaDTO          `json:"delta,omitempty"`
 	BuildWarning           string             `json:"build_warning,omitempty"`
+	UnanalyzedTools        []string           `json:"unanalyzed_tools,omitempty"`
 }
 
 type responseDTO struct {
@@ -124,6 +125,7 @@ func toProjectDTO(result pipeline.Result) projectDTO {
 		Violations:             toViolationDTOs(result),
 		Delta:                  toDeltaDTO(result),
 		BuildWarning:           result.BuildWarning,
+		UnanalyzedTools:        result.UnanalyzedTools,
 	}
 }
 

--- a/core/userinterface/cli/judge/pipeline/local.go
+++ b/core/userinterface/cli/judge/pipeline/local.go
@@ -84,8 +84,9 @@ func mapSubmitResult(res submit.Result, collected collectevidence.Result, projec
 			NewViolationIDs:         res.Delta.NewViolationIDs,
 			HasArchPrevious:         res.Delta.HasArchPrevious,
 		},
-		FirstRun:     !res.Delta.HasPrevious,
-		RawSARIFDocs: collected.SARIFDocs,
-		BuildWarning: collected.BuildWarning,
+		FirstRun:        !res.Delta.HasPrevious,
+		RawSARIFDocs:    collected.SARIFDocs,
+		BuildWarning:    collected.BuildWarning,
+		UnanalyzedTools: collected.UnanalyzedTools,
 	}
 }

--- a/core/userinterface/cli/judge/pipeline/result.go
+++ b/core/userinterface/cli/judge/pipeline/result.go
@@ -28,4 +28,5 @@ type Result struct {
 	RawSARIFDocs           [][]byte
 	ServerFailed           bool
 	BuildWarning           string
+	UnanalyzedTools        []string
 }

--- a/core/userinterface/cli/ui/render.go
+++ b/core/userinterface/cli/ui/render.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -111,9 +112,9 @@ func BuildWarning() string {
 	return GoldBar.Render("  ⚠ bazel build had failures — results may be incomplete; verdict is unreliable") + "\n"
 }
 
-func MissingTargetsWarning(project, language, pattern string) string {
-	msg := fmt.Sprintf("  ⚠ project %s declares tooling: %s, but no matching targets exist under %s; aspects will produce zero findings",
-		project, language, pattern)
+func MissingTargetsWarning(project string, tools []string) string {
+	msg := fmt.Sprintf("  ⚠ project %s enables %s, but no analyzable targets were found — those tools produced zero findings and are not covered by this verdict",
+		project, strings.Join(tools, ", "))
 	return GoldBar.Render(msg) + "\n"
 }
 

--- a/core/userinterface/cli/ui/render_test.go
+++ b/core/userinterface/cli/ui/render_test.go
@@ -204,10 +204,10 @@ func TestBuildWarning(t *testing.T) {
 }
 
 func TestMissingTargetsWarning(t *testing.T) {
-	got := ui.MissingTargetsWarning("web", "typescript", "//apps/web/...")
+	got := ui.MissingTargetsWarning("web", []string{"eslint", "archtest"})
 	assert.Contains(t, got, "web")
-	assert.Contains(t, got, "typescript")
-	assert.Contains(t, got, "//apps/web/...")
+	assert.Contains(t, got, "eslint")
+	assert.Contains(t, got, "archtest")
 	assert.Contains(t, got, "zero findings")
 }
 


### PR DESCRIPTION
## Problem — a false guarantee

A lint aspect emits one SARIF submission per target it attaches to. An **enabled tool that produced zero submissions attached to nothing** — it analyzed zero targets. Until now that vanished silently: `collectAllSARIF` drops empty aspects from the result map, so the tool contributed no findings and left no trace, and the verdict went **green as if the language were clean**.

The common case is **TypeScript**. In a Bazel monorepo the frontend usually lives in a pnpm/Next.js subtree with **no `ts_project`/`js_library` targets**, so gavel's `JsInfo`-based eslint aspect sees nothing. The user enables `typescript: [eslint]`, reads a passing verdict, and believes their TS is clean — when it was never looked at.

Found while running `gavel judge` against [nativelink](https://github.com/TraceMachina/nativelink) (Rust backend in Bazel, 64 `.ts` files in a `web/` pnpm subtree with 0 Bazel TS targets): TS reported 0 findings and passed, indistinguishable from genuinely-clean.

## Fix — stop the green from lying

`ToolsWithoutSubmissions` compares the configured lint aspects against the aspects that actually produced SARIF and reports the gap up through the findings collector to the judge output:
- **JSON**: new `unanalyzed_tools` field per project.
- **Human render**: a per-project warning (adopts the previously-orphaned `MissingTargetsWarning`, which had a test but was never wired).

The verdict itself is **unchanged** — this is purely honesty, not gating. (Whether to also *analyze* non-Bazel TS is a separate, deliberately-out-of-scope architectural decision.)

## Verified end-to-end

On nativelink, judge now emits:
```json
"unanalyzed_tools": ["typescript_eslint_submission_aspect"]
```
alongside the 8 real Rust/clippy findings, instead of a silent green for TS.

## Tests (TDD)
- `ToolsWithoutSubmissions` — pure detection, red→green (runner).
- Collector propagates the unanalyzed list when an aspect produced no SARIF.
- Handler propagates `UnanalyzedTools` into the result.
- `MissingTargetsWarning` render updated to the `(project, tools)` shape.

All affected packages pass under `bazel test`.