### PR TITLE
docs(quickstart): declare the Bazel 8.0 floor and the hermetic-network allowlist

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,9 +7,29 @@ tags: [quickstart, getting-started]
 
 # Quickstart
 
-From zero to first quality report in 5 minutes. Requires a Bazel workspace
-with `MODULE.bazel` (bzlmod). Runs on Linux and macOS (amd64/arm64);
-Windows is not supported.
+From zero to first quality report in 5 minutes.
+
+## Requirements
+
+| Requirement | Supported |
+|-------------|-----------|
+| Bazel       | **8.0 or newer**, bzlmod (`MODULE.bazel`) |
+| OS          | Linux, macOS (amd64 / arm64) — Windows is not supported |
+
+Bazel **8.0** is the floor: gavel's Go analyzer references `rules_go` by the
+canonical repository name Bazel 8 mints (`rules_go+`), and Bazel 7 uses a
+different scheme (`rules_go~`) that cannot resolve it, so `gavel judge` fails at
+repository resolution before any build runs. Non-Go repos may still work on
+Bazel 7, but 7.x is unsupported. The flag itself lives in
+[`catalog.yaml`](../core/infrastructure/platform/bazel/catalog/catalog.yaml).
+
+**Restricted / hermetic networks.** `gavel init` adds the gavel module registry
+(`gavelcode.github.io`) to your `.bazelrc`, and `gavel_tools` fetches its
+analyzer binaries from `github.com` and `repo1.maven.org`. A repo with a
+locked-down `--downloader_config` (an allowlist plus `block *` mirror) must
+allowlist those hosts, or vendor `gavel_tools` into its own mirror — gavel
+cannot bypass a hermetic download policy, by design. The authoritative host
+list is `gavel_tools`' `lint/lang/*/*/repositories.bzl`.
 
 ## 1. Install
 


### PR DESCRIPTION
Two adoption frictions surfaced by running `gavel judge` against public Bazel monorepos — both resolved by **stating requirements** rather than engineering around them.

## #2 — Bazel version floor

gavel's Go analyzer references `rules_go` by the canonical repository name Bazel 8 mints (`rules_go+`). Bazel 7 uses a different scheme (`rules_go~`) and cannot resolve the flag, so `gavel judge` fails at repository resolution before any build runs:

```
ERROR: Repository '@@rules_go+' is not defined
```

Rather than carry a portable dual-name shim, declare **Bazel 8.0** as the supported floor. Evidence: bazel-watcher (7.6.2) failed; monogon (8.3.1) worked. Documented as a compatibility matrix in the quickstart requirements.

## #3 — Hermetic / restricted networks

A repo with a `--downloader_config` allowlist + `block *` mirror (e.g. [monogon](https://github.com/monogon-dev/monogon)) blocks `gavelcode.github.io`, so `gavel init`'s registry and the `gavel_tools` analyzer binaries never download. gavel **cannot and should not** bypass a deliberate hermetic policy — so document the hosts to allowlist (`gavelcode.github.io`, `github.com`, `repo1.maven.org`), or the vendor-`gavel_tools`-into-your-mirror path, pointing to `repositories.bzl` as the authoritative host list.

## Scope

Docs only — a single `Requirements` section added to `docs/quickstart.md`. No code change; per the earlier discussion, #2 is handled as a supported-version declaration and #3 as consumer-side configuration guidance.