### PR TITLE
fix(judge): treat incomplete tool analysis as a warning, not a gate failure

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ bazel_dep(name = "aspect_rules_ts", version = "3.8.8")
 bazel_dep(name = "aspect_rules_esbuild", version = "0.25.1")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
 bazel_dep(name = "rules_rust", version = "0.70.0")
-bazel_dep(name = "gavel_tools", version = "0.3.7")
+bazel_dep(name = "gavel_tools", version = "0.3.8")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.25.7")

--- a/core/application/casefile/evidencedto/toolexecution.go
+++ b/core/application/casefile/evidencedto/toolexecution.go
@@ -11,8 +11,9 @@ type ToolExecution struct {
 }
 
 type ToolFailure struct {
-	Tool   string
-	Reason string
+	Tool     string
+	Reason   string
+	Degraded bool
 }
 
 func fromDomainToolExecution(content toolexecution.Content) ToolExecution {
@@ -20,8 +21,9 @@ func fromDomainToolExecution(content toolexecution.Content) ToolExecution {
 	out := make([]ToolFailure, 0, len(failures))
 	for _, failed := range failures {
 		out = append(out, ToolFailure{
-			Tool:   failed.Tool(),
-			Reason: failed.Reason(),
+			Tool:     failed.Tool(),
+			Reason:   failed.Reason(),
+			Degraded: failed.Degraded(),
 		})
 	}
 	return ToolExecution{Failures: out}
@@ -30,11 +32,18 @@ func fromDomainToolExecution(content toolexecution.Content) ToolExecution {
 func toDomainToolExecution(in ToolExecution) (toolexecution.Content, error) {
 	failures := make([]toolexecution.Failure, 0, len(in.Failures))
 	for i, failed := range in.Failures {
-		tf, err := toolexecution.NewFailure(failed.Tool, failed.Reason)
+		tf, err := newToolFailure(failed)
 		if err != nil {
 			return toolexecution.Content{}, fmt.Errorf("failures[%d]: %w", i, err)
 		}
 		failures = append(failures, tf)
 	}
 	return toolexecution.NewContent(failures)
+}
+
+func newToolFailure(failed ToolFailure) (toolexecution.Failure, error) {
+	if failed.Degraded {
+		return toolexecution.NewDegradedFailure(failed.Tool, failed.Reason)
+	}
+	return toolexecution.NewFailure(failed.Tool, failed.Reason)
 }

--- a/core/domain/casefile/model/casefile.go
+++ b/core/domain/casefile/model/casefile.go
@@ -114,15 +114,29 @@ func (cf *CaseFile) Judge(qualityGate qualitygate.Gate, tracking *tracking.Resul
 }
 
 func (cf *CaseFile) toolExecutionRuling(grouped map[evidence.Subtype]evidence.Content) verdict.Ruling {
-	failures := toolExecutionFailures(grouped)
-	if len(failures) == 0 {
-		return verdict.NewRuling(evidence.SubtypeToolExecution, true, "")
+	var hard, degraded []toolexecution.Failure
+	for _, failed := range toolExecutionFailures(grouped) {
+		if failed.Degraded() {
+			degraded = append(degraded, failed)
+		} else {
+			hard = append(hard, failed)
+		}
 	}
+	if len(hard) > 0 {
+		return verdict.NewRuling(evidence.SubtypeToolExecution, false, toolExecutionReasons(hard))
+	}
+	if len(degraded) > 0 {
+		return verdict.NewRuling(evidence.SubtypeToolExecution, true, "incomplete analysis — "+toolExecutionReasons(degraded))
+	}
+	return verdict.NewRuling(evidence.SubtypeToolExecution, true, "")
+}
+
+func toolExecutionReasons(failures []toolexecution.Failure) string {
 	reasons := make([]string, 0, len(failures))
 	for _, failed := range failures {
 		reasons = append(reasons, fmt.Sprintf("%s: %s", failed.Tool(), failed.Reason()))
 	}
-	return verdict.NewRuling(evidence.SubtypeToolExecution, false, strings.Join(reasons, "; "))
+	return strings.Join(reasons, "; ")
 }
 
 func toolExecutionFailures(grouped map[evidence.Subtype]evidence.Content) []toolexecution.Failure {

--- a/core/domain/casefile/model/casefile_test.go
+++ b/core/domain/casefile/model/casefile_test.go
@@ -334,9 +334,54 @@ func TestCaseFileJudgeToolExecutionRulingAlwaysPresent(t *testing.T) {
 	assert.True(t, ruling.Passed())
 }
 
+func TestCaseFileJudgeDoesNotFailOnDegradedToolExecution(t *testing.T) {
+	caseF := mustNewCaseFile(t)
+	require.NoError(t, caseF.AddEvidence(mustCodeQualityEvidenceWithFindings(t, "pmd", testTime, nil), testTime))
+	degraded := mustDegradedFailure(t, "ErrorProne", "13 javac compilation error(s); results are incomplete")
+	require.NoError(t, caseF.AddEvidence(mustToolExecutionEvidence(t, "ErrorProne", testTime, []toolexecution.Failure{degraded}), testTime))
+
+	qGate := mustQualityGate(t, qualitygate.NewZeroTolerance())
+
+	result, err := caseF.Judge(qGate, nil, testTime, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "pass", result.Outcome().String(), "an incomplete analysis must not fail the verdict")
+	ruling := findRuling(t, result, evidence.SubtypeToolExecution)
+	assert.True(t, ruling.Passed())
+	assert.Contains(t, ruling.Detail(), "incomplete analysis")
+	assert.Contains(t, ruling.Detail(), "ErrorProne")
+}
+
+func TestCaseFileJudgeFailsWhenHardFailureAccompaniesDegraded(t *testing.T) {
+	caseF := mustNewCaseFile(t)
+	require.NoError(t, caseF.AddEvidence(mustCodeQualityEvidenceWithFindings(t, "pmd", testTime, nil), testTime))
+	failures := []toolexecution.Failure{
+		mustDegradedFailure(t, "ErrorProne", "results are incomplete"),
+		mustFailure(t, "pmd", "could not launch"),
+	}
+	require.NoError(t, caseF.AddEvidence(mustToolExecutionEvidence(t, "java", testTime, failures), testTime))
+
+	qGate := mustQualityGate(t, qualitygate.NewZeroTolerance())
+
+	result, err := caseF.Judge(qGate, nil, testTime, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "fail", result.Outcome().String(), "a genuine hard failure must still fail even when a degraded run is present")
+	ruling := findRuling(t, result, evidence.SubtypeToolExecution)
+	assert.False(t, ruling.Passed())
+	assert.Contains(t, ruling.Detail(), "pmd")
+}
+
 func mustFailure(t *testing.T, tool, reason string) toolexecution.Failure {
 	t.Helper()
 	failed, err := toolexecution.NewFailure(tool, reason)
+	require.NoError(t, err)
+	return failed
+}
+
+func mustDegradedFailure(t *testing.T, tool, reason string) toolexecution.Failure {
+	t.Helper()
+	failed, err := toolexecution.NewDegradedFailure(tool, reason)
 	require.NoError(t, err)
 	return failed
 }

--- a/core/domain/casefile/model/evidence/toolexecution/failure.go
+++ b/core/domain/casefile/model/evidence/toolexecution/failure.go
@@ -6,11 +6,24 @@ import (
 )
 
 type Failure struct {
-	tool   string
-	reason string
+	tool     string
+	reason   string
+	degraded bool
 }
 
 func NewFailure(tool, reason string) (Failure, error) {
+	return newFailure(tool, reason, false)
+}
+
+// NewDegradedFailure records a tool that ran but could not analyze completely
+// (e.g. Error Prone whose javac hit unresolved symbols because the target uses
+// annotation processors). The analysis is partial, not broken, so it must not
+// fail the verdict — only surface honestly that coverage was incomplete.
+func NewDegradedFailure(tool, reason string) (Failure, error) {
+	return newFailure(tool, reason, true)
+}
+
+func newFailure(tool, reason string, degraded bool) (Failure, error) {
 	if strings.TrimSpace(tool) == "" {
 		return Failure{}, fmt.Errorf("%w: tool must not be empty", ErrInvalidFailure)
 	}
@@ -19,10 +32,12 @@ func NewFailure(tool, reason string) (Failure, error) {
 	}
 
 	return Failure{
-		tool:   tool,
-		reason: reason,
+		tool:     tool,
+		reason:   reason,
+		degraded: degraded,
 	}, nil
 }
 
 func (f Failure) Tool() string   { return f.tool }
 func (f Failure) Reason() string { return f.reason }
+func (f Failure) Degraded() bool { return f.degraded }

--- a/core/infrastructure/casefile/sarif/executions.go
+++ b/core/infrastructure/casefile/sarif/executions.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	unknownTool = "unknown"
-	errorLevel  = "error"
+	unknownTool  = "unknown"
+	errorLevel   = "error"
+	warningLevel = "warning"
 )
 
 func (*Parser) ParseToolExecutions(data []byte) ([]evidencedto.ToolFailure, error) {
@@ -30,7 +31,17 @@ func (*Parser) ParseToolExecutions(data []byte) ([]evidencedto.ToolFailure, erro
 			toolName = unknownTool
 		}
 		for _, inv := range currentRun.Invocations {
-			if inv.ExecutionSuccessful || isConfigurationOnly(inv) {
+			if inv.ExecutionSuccessful {
+				if reason := degradedReason(inv); reason != "" {
+					failures = append(failures, evidencedto.ToolFailure{
+						Tool:     toolName,
+						Reason:   reason,
+						Degraded: true,
+					})
+				}
+				continue
+			}
+			if isConfigurationOnly(inv) {
 				continue
 			}
 			failures = append(failures, evidencedto.ToolFailure{
@@ -40,6 +51,23 @@ func (*Parser) ParseToolExecutions(data []byte) ([]evidencedto.ToolFailure, erro
 		}
 	}
 	return failures, nil
+}
+
+// degradedReason collects the warning-level execution notifications a tool
+// attaches to a *successful* run — its way of saying "I ran but could only
+// analyze part of this" (e.g. Error Prone on a target whose annotation
+// processors it could not replay). Returns "" when the run was clean.
+func degradedReason(inv invocation) string {
+	var texts []string
+	for _, note := range inv.ToolExecutionNotifications {
+		if !strings.EqualFold(strings.TrimSpace(note.Level), warningLevel) {
+			continue
+		}
+		if text := strings.TrimSpace(note.Message.Text); text != "" {
+			texts = append(texts, text)
+		}
+	}
+	return strings.Join(texts, "; ")
 }
 
 func isConfigurationOnly(inv invocation) bool {

--- a/core/infrastructure/casefile/sarif/executions_test.go
+++ b/core/infrastructure/casefile/sarif/executions_test.go
@@ -27,6 +27,28 @@ func TestParseToolExecutionsSuccess(t *testing.T) {
 	assert.Empty(t, failures)
 }
 
+func TestParseToolExecutionsDegradedOnSuccessfulWarning(t *testing.T) {
+	data := []byte(`{"runs":[{"tool":{"driver":{"name":"ErrorProne"}},"results":[],"invocations":[{"executionSuccessful":true,"toolExecutionNotifications":[{"level":"warning","message":{"text":"13 javac compilation error(s) prevented complete Error Prone analysis; results are incomplete"}}]}]}]}`)
+
+	failures, err := NewParser().ParseToolExecutions(data)
+
+	require.NoError(t, err)
+	require.Len(t, failures, 1)
+	assert.True(t, failures[0].Degraded,
+		"a successful run carrying a warning-level notification is incomplete, not failed, and must not gate the verdict")
+	assert.Contains(t, failures[0].Reason, "results are incomplete")
+}
+
+func TestParseToolExecutionsHardFailureIsNotDegraded(t *testing.T) {
+	data := []byte(`{"runs":[{"tool":{"driver":{"name":"ErrorProne"}},"results":[],"invocations":[{"executionSuccessful":false,"toolExecutionNotifications":[{"level":"error","message":{"text":"Error Prone could not run javac"}}]}]}]}`)
+
+	failures, err := NewParser().ParseToolExecutions(data)
+
+	require.NoError(t, err)
+	require.Len(t, failures, 1)
+	assert.False(t, failures[0].Degraded)
+}
+
 func TestParseToolExecutionsNoInvocations(t *testing.T) {
 	data := []byte(`{"runs":[{"tool":{"driver":{"name":"pmd"}},"results":[]}]}`)
 

--- a/core/infrastructure/platform/bazel/installer/install_test.go
+++ b/core/infrastructure/platform/bazel/installer/install_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/usegavel/gavel/core/infrastructure/platform/bazel/installer"
 )
 
-const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.7")`
+const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "0.3.8")`
 
 const (
 	gavelRegistryLine = "common --registry=https://gavelcode.github.io/registry"

--- a/core/infrastructure/platform/bazel/installer/installer.go
+++ b/core/infrastructure/platform/bazel/installer/installer.go
@@ -24,7 +24,7 @@ const moduleInclude = `include("//:.gavel/gavel.MODULE.bazel")`
 
 const GavelBazelrc = ".gavel/gavel.bazelrc"
 const GavelModule = ".gavel/gavel.MODULE.bazel"
-const gavelToolsVersion = "0.3.7"
+const gavelToolsVersion = "0.3.8"
 const gavelDepLine = `bazel_dep(name = "gavel_tools", version = "` + gavelToolsVersion + `")`
 
 type Installer struct{}

--- a/examples/go-repo/MODULE.bazel
+++ b/examples/go-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.7")
+bazel_dep(name = "gavel_tools", version = "0.3.8")
 bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "gazelle", version = "0.50.0")
 

--- a/examples/java-repo/MODULE.bazel
+++ b/examples/java-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.7")
+bazel_dep(name = "gavel_tools", version = "0.3.8")
 bazel_dep(name = "rules_java", version = "9.1.0")
 
 include("//:.gavel/gavel.MODULE.bazel")

--- a/examples/python-repo/MODULE.bazel
+++ b/examples/python-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.7")
+bazel_dep(name = "gavel_tools", version = "0.3.8")
 bazel_dep(name = "rules_python", version = "1.7.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/examples/rust-fullstack-repo/MODULE.bazel
+++ b/examples/rust-fullstack-repo/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "gavel_tools", version = "0.3.7")
+bazel_dep(name = "gavel_tools", version = "0.3.8")
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "aspect_rules_js", version = "3.0.3")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.8")


### PR DESCRIPTION
## Problem

`tool_execution` collapsed two very different outcomes into a single **FAIL**:
1. A tool that **could not run at all** (real failure).
2. A tool that **ran but could only analyze part of the target** (degraded).

The second is the common case for **Error Prone on any repo using annotation processors** (Lombok, AutoValue, Dagger, MapStruct…): its isolated javac hits unresolved symbols, Error Prone reports what it could and flags the run incomplete. gavel then **failed the verdict of an otherwise-clean repo** for a reason unrelated to code quality — observed on buildfarm (Lombok), where `tool_execution` came back FAIL.

Same class of bug as the TypeScript false-green we just fixed: gavel giving a wrong verdict on a legitimate input.

## Fix

Split the two outcomes. A `toolexecution.Failure` now carries a `degraded` flag:
- **Hard failure** (`executionSuccessful=false`) → still fails the gate.
- **Degraded** (a tool reports warning-level `toolExecutionNotifications` on a *successful* invocation) → the gate **passes**, but the `tool_execution` ruling carries an honest `incomplete analysis — …` detail so the gap is never silent.

Never fail on a legitimate input; never hide that coverage was partial.

## Scope / compatibility

- gavel side only (domain `Failure` + ruling + DTO + SARIF parser).
- **Backward-compatible** with the current wrapper: `executionSuccessful=false` keeps failing. It starts honoring degraded runs the moment the matching `gavel_tools` wrapper (emits `executionSuccessful=true` + warning notification for the incomplete case) lands and the pin is bumped.

## Tests (TDD)
- Parser: successful invocation + warning notification → degraded failure; hard failure stays non-degraded.
- Ruling: degraded-only → PASS with `incomplete analysis` detail; a hard failure alongside a degraded one still FAILs.