### PR TITLE
feat(judge): add --summary to print the verdict without the per-finding list

### DIFF
--- a/clispec/v1/clispec.yaml
+++ b/clispec/v1/clispec.yaml
@@ -76,6 +76,10 @@ commands:
         short: q
         default: false
         description: Run findings only, skip coverage and architecture checks.
+      summary:
+        type: bool
+        default: false
+        description: Print only the verdict, delta, and rulings; omit the per-finding list.
       absolute:
         type: bool
         default: false

--- a/core/userinterface/cli/judge/flags.gen.go
+++ b/core/userinterface/cli/judge/flags.gen.go
@@ -28,6 +28,7 @@ type Options struct {
 	Quick bool
 	RequireSubmit bool
 	ServerURL string
+	Summary bool
 	TargetFile string
 	Timeout time.Duration
 	ServerToken string
@@ -53,6 +54,7 @@ func RegisterFlags(cmd *cobra.Command, opts *Options) {
 	cmd.Flags().BoolVarP(&opts.Quick, "quick", "q", false, "Run findings only, skip coverage and architecture checks.")
 	cmd.Flags().BoolVar(&opts.RequireSubmit, "require-submit", false, "Exit with error if server submission fails. Default behavior is warn and continue.")
 	cmd.Flags().StringVar(&opts.ServerURL, "server", envOrDefault("GAVEL_SERVER_URL", ""), "Gavel server URL for shared baseline and result submission.")
+	cmd.Flags().BoolVar(&opts.Summary, "summary", false, "Print only the verdict, delta, and rulings; omit the per-finding list.")
 	cmd.Flags().StringVar(&opts.TargetFile, "target-file", "", "File path relative to workspace root. Resolves the owning Bazel package and analyzes only that target. Implies --quick.")
 	cmd.Flags().DurationVar(&opts.Timeout, "timeout", 30 * time.Minute, "Maximum time for the entire judge run.")
 	cmd.Flags().StringVar(&opts.ServerToken, "token", envOrDefault("GAVEL_TOKEN", ""), "API token for server authentication.")

--- a/core/userinterface/cli/judge/judge.go
+++ b/core/userinterface/cli/judge/judge.go
@@ -268,11 +268,13 @@ func emitResults(writer io.Writer, results []pipeline.Result, opts Options, star
 	}
 	elapsed := time.Since(startedAt)
 	for _, projResult := range results {
-		if _, err := fmt.Fprint(writer, render.Findings(projResult)); err != nil {
-			return err
-		}
-		if _, err := fmt.Fprint(writer, render.CoverageSummary(projResult)); err != nil {
-			return err
+		if !opts.Summary {
+			if _, err := fmt.Fprint(writer, render.Findings(projResult)); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprint(writer, render.CoverageSummary(projResult)); err != nil {
+				return err
+			}
 		}
 		if _, err := fmt.Fprint(writer, ui.JudgeVerdict(projResult.Verdict, projResult.Name, projResult.FindingsCount, projResult.ViolationsCount, projResult.CoveragePercent, projResult.CoverageSkipped, elapsed)); err != nil {
 			return err

--- a/core/userinterface/cli/judge/judge_test.go
+++ b/core/userinterface/cli/judge/judge_test.go
@@ -1219,3 +1219,21 @@ func TestRun_JudgeHeaderWriteError(t *testing.T) {
 
 	require.Error(t, err)
 }
+
+func TestEmitResults_SummaryOmitsFindingList(t *testing.T) {
+	result := pipeline.Result{
+		Name:    "api",
+		Verdict: "fail",
+		Findings: []evidencedto.Finding{
+			{FilePath: "internal/foo.go", Line: 10, Severity: "error", Message: "boom", Tool: "golangci-lint", RuleID: "errcheck"},
+		},
+	}
+
+	var full, summary bytes.Buffer
+	require.NoError(t, emitResults(&full, []pipeline.Result{result}, Options{}, time.Now()))
+	require.NoError(t, emitResults(&summary, []pipeline.Result{result}, Options{Summary: true}, time.Now()))
+
+	assert.Contains(t, full.String(), "internal/foo.go", "default output lists each finding")
+	assert.NotContains(t, summary.String(), "internal/foo.go", "summary omits the per-finding list")
+	assert.Contains(t, summary.String(), "VERDICT", "summary still shows the verdict")
+}


### PR DESCRIPTION
## Problem

`gavel judge` always dumps every finding file-by-file — **213 lines** on a 146-finding project — then the verdict. `--quick` doesn't help: it narrows *which checks run* (skips coverage + architecture), not the output, so the finding list is just as long. The result buries the verdict and the new-vs-baseline delta, and floods CI logs.

(`--quick` = analysis scope · output verbosity = a different axis entirely.)

## Fix

`--summary` keeps the **verdict**, the **delta** (`N new · M fixed · K existing`), and the per-dimension **rulings**, but omits the per-finding list and the coverage-by-directory tree.

```
$ gavel judge --quick --summary        # 213 lines → 13
⚖  VERDICT: FAIL — 146 findings — api-gateway  (6s)
  1 new · 1 fixed · 145 existing
  ├─ code_quality: FAIL — 1 errors (max 0)
  ├─ coverage: PASS
  ├─ architecture: PASS
  └─ tool_execution: PASS
```

`--quick` and `--summary` are orthogonal and compose. Verdict, exit code, and JSON output (`--json`) are all unchanged — this only gates the human finding-list render.

## Tests (TDD)
- `TestEmitResults_SummaryOmitsFindingList`: default output lists findings; `--summary` omits them but still shows the verdict.
- Flag added to `clispec/v1/clispec.yaml`; `flags.gen.go` regenerated (`make clispec-gen`); clispec integration tests pass.