### PR TITLE
Arch violation detail + runProject refactor

### DIFF
--- a/core/userinterface/cli/judge/judge.go
+++ b/core/userinterface/cli/judge/judge.go
@@ -402,44 +402,9 @@ func runProject(
 		return pipeline.Result{}, err
 	}
 
-	if interactive {
-		spinner := ui.NewSpinnerWithMessage(writer, "collecting evidence")
-		go spinner.Run()
-		collected, err := deps.collectEvH.Execute(ctx, collectCmd)
-		spinner.Stop()
-		if err != nil {
-			return pipeline.Result{}, err
-		}
-		if collected.BuildWarning != "" {
-			deps.log.Warn("bazel build had partial failures", "detail", collected.BuildWarning)
-		}
-
-		spinner = ui.NewSpinnerWithMessage(writer, "evaluating quality gate")
-		go spinner.Run()
-		result, err := pipeline.RunProject(ctx, pipeline.Deps{
-			Log:          deps.log,
-			Submit:       deps.submitH,
-			Findings:     deps.findings,
-			Coverage:     deps.coverage,
-			ServerClient: deps.serverClient,
-		}, workspace, collected, tenantID, project.ID, project.Name, commitSHA, branch, startedAt, pipeline.Options{
-			Quick:            opts.Quick,
-			Absolute:         opts.Absolute,
-			NoBaselineUpdate: opts.NoBaselineUpdate,
-			RequireSubmit:    opts.RequireSubmit,
-			PRNumber:         opts.PRNumber,
-			PRTitle:          opts.PRTitle,
-			PRAuthor:         opts.PRAuthor,
-			PRBranch:         opts.PRBranch,
-			Gavelspace:       opts.Gavelspace,
-			TargetPattern:    project.TargetPattern,
-			Workspace:        workspace,
-		})
-		spinner.Stop()
-		return result, err
-	}
-
-	collected, err := deps.collectEvH.Execute(ctx, collectCmd)
+	collected, err := withSpinner(writer, interactive, "collecting evidence", func() (collectevidence.Result, error) {
+		return deps.collectEvH.Execute(ctx, collectCmd)
+	})
 	if err != nil {
 		return pipeline.Result{}, err
 	}
@@ -447,13 +412,14 @@ func runProject(
 		deps.log.Warn("bazel build had partial failures", "detail", collected.BuildWarning)
 	}
 
-	return pipeline.RunProject(ctx, pipeline.Deps{
+	pipeDeps := pipeline.Deps{
 		Log:          deps.log,
 		Submit:       deps.submitH,
 		Findings:     deps.findings,
 		Coverage:     deps.coverage,
 		ServerClient: deps.serverClient,
-	}, workspace, collected, tenantID, project.ID, project.Name, commitSHA, branch, startedAt, pipeline.Options{
+	}
+	pipeOpts := pipeline.Options{
 		Quick:            opts.Quick,
 		Absolute:         opts.Absolute,
 		NoBaselineUpdate: opts.NoBaselineUpdate,
@@ -465,5 +431,19 @@ func runProject(
 		Gavelspace:       opts.Gavelspace,
 		TargetPattern:    project.TargetPattern,
 		Workspace:        workspace,
+	}
+	return withSpinner(writer, interactive, "evaluating quality gate", func() (pipeline.Result, error) {
+		return pipeline.RunProject(ctx, pipeDeps, workspace, collected, tenantID, project.ID, project.Name, commitSHA, branch, startedAt, pipeOpts)
 	})
+}
+
+func withSpinner[T any](writer io.Writer, interactive bool, message string, operation func() (T, error)) (T, error) {
+	if !interactive {
+		return operation()
+	}
+	spinner := ui.NewSpinnerWithMessage(writer, message)
+	go spinner.Run()
+	result, err := operation()
+	spinner.Stop()
+	return result, err
 }

--- a/core/userinterface/cli/judge/judge_test.go
+++ b/core/userinterface/cli/judge/judge_test.go
@@ -91,6 +91,25 @@ func newTestDeps(findingsParser ingestfind.Parser, coverageParser ingestcov.Pars
 	}
 }
 
+func TestWithSpinner_NonInteractiveRunsFn(t *testing.T) {
+	got, err := withSpinner(io.Discard, false, "x", func() (int, error) { return 7, nil })
+	require.NoError(t, err)
+	assert.Equal(t, 7, got)
+}
+
+func TestWithSpinner_InteractiveRunsFnAndReturnsValue(t *testing.T) {
+	var buf bytes.Buffer
+	got, err := withSpinner(&buf, true, "working", func() (string, error) { return "ok", nil })
+	require.NoError(t, err)
+	assert.Equal(t, "ok", got)
+}
+
+func TestWithSpinner_PropagatesError(t *testing.T) {
+	_, err := withSpinner(io.Discard, false, "x", func() (int, error) { return 0, errors.New("boom") })
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
 func TestResolveConfigPath_ExplicitOverride(t *testing.T) {
 	got := resolveConfigPath("/custom/gavel.yaml", "/some/workspace")
 	assert.Equal(t, "/custom/gavel.yaml", got)

--- a/core/userinterface/cli/mcp/tools/arch.go
+++ b/core/userinterface/cli/mcp/tools/arch.go
@@ -71,6 +71,9 @@ func formatArchOutput(output []byte) (string, error) {
 				marker = "  " + statusNewLabel
 			}
 			fmt.Fprintf(&builder, "  %s: %s → %s%s\n", violation.Rule, violation.SourcePkg, violation.TargetPkg, marker)
+			if violation.Message != "" {
+				fmt.Fprintf(&builder, "    %s\n", violation.Message)
+			}
 		}
 		builder.WriteString("\n")
 	}

--- a/core/userinterface/cli/mcp/tools/judge.go
+++ b/core/userinterface/cli/mcp/tools/judge.go
@@ -154,6 +154,9 @@ func formatJudgeOutput(output []byte, exitCode int) (string, error) {
 					marker = "  " + statusNewLabel
 				}
 				fmt.Fprintf(&builder, "  %s: %s → %s%s\n", violation.Rule, violation.SourcePkg, violation.TargetPkg, marker)
+				if violation.Message != "" {
+					fmt.Fprintf(&builder, "    %s\n", violation.Message)
+				}
 			}
 		}
 		if proj.CoveragePercent != nil {

--- a/core/userinterface/cli/mcp/tools/run_test.go
+++ b/core/userinterface/cli/mcp/tools/run_test.go
@@ -409,6 +409,7 @@ func TestRunJudge_ShowsViolationDetails(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, result, "no_infra_in_domain: domain/foo → infra/bar")
 	assert.Contains(t, result, "no_ui_in_app: application/baz → userinterface/qux")
+	assert.Contains(t, result, "forbidden import")
 }
 
 func TestRunJudge_ShowsNewViolationMarker(t *testing.T) {
@@ -443,6 +444,8 @@ func TestRunArch_WithViolations(t *testing.T) {
 	assert.Contains(t, result, "no_infra_in_domain: domain/foo → infra/bar")
 	assert.Contains(t, result, "no_ui_in_app: application/baz → userinterface/qux")
 	assert.Contains(t, result, "NEW")
+	assert.Contains(t, result, "forbidden import")
+	assert.Contains(t, result, "layer violation")
 }
 
 func TestRunArch_WithProjectFilter(t *testing.T) {


### PR DESCRIPTION
Two independent improvements, each with tests.

## `feat`: surface the offending import in architecture violations

`gavel_arch` (and `gavel_judge`) printed only the layer direction —
`domain-imports-nothing: domain → infrastructure` — with no hint of *which* file
does the forbidden import. That's the one thing you need to actually fix it. The
message with the concrete import was already parsed into the DTO but never
rendered. Now:

```
  domain-imports-nothing: domain → infrastructure  NEW
    internal/domain/payment/baseline_probe.go imports internal/infrastructure/persistence (...)
```

No domain/API changes — purely surfacing data that was already flowing through.

## `refactor`: unify runProject's interactive/non-interactive paths

`runProject` had two branches that duplicated the entire `pipeline.Deps` +
`Options` literal and the `RunProject` call, differing only in spinner wrapping.
That duplication left the interactive copy untested (the recent patch-coverage
dip) and meant every new `Options` field had to be edited in two places. Extract
a small generic `withSpinner` helper and build `Deps`/`Options` once, so there's a
single `RunProject` call. Adds direct tests for the helper, covering the
previously untested interactive branch.

## Verification

- TDD for both: failing test first, then the change.
- Full `judge` and `mcp/...` suites green; `gofmt` + `go vet` clean.
- Arch detail verified live against `examples/go-repo`.
- Uncovered lines in `judge.go` dropped (the interactive duplication is gone;
  what remains is pre-existing untested error/branch paths).
