### PR TITLE
chore: claim MCP server on Glama (glama.json)

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["JorgeOlmosDev"]
+}


### PR DESCRIPTION
Adds `glama.json` with the maintainer, so the gavel MCP server is claimed and indexed in the [Glama MCP registry](https://glama.ai/mcp/servers). Minimal per Glama's official schema (`maintainers` only).