### PR TITLE
build(deps): split web npm group so majors land in their own PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,12 @@ updates:
     directory: /apps/web
     schedule: { interval: weekly }
     groups:
-      web: { patterns: ["*"] }
+      web:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      web-major:
+        patterns: ["*"]
+        update-types: ["major"]
   - package-ecosystem: github-actions
     directory: /
     schedule: { interval: weekly }


### PR DESCRIPTION
## Why

The npm group for `/apps/web` used `patterns: ["*"]`, so **all 26 updates (patches + majors) arrive as one atomic Dependabot PR** (#32). Dependabot treats a group as a unit, so the safe patches can't be merged while a major breaks CI.

In #32 the `test` check fails at the Bazel/rules_js load step:
```
ERROR: cannot load '@@...npm//apps/web:tailwindcss/package_json.bzl': no such file
```
i.e. a **major** (`tailwindcss` 3→4) breaks the web build, blocking 20 safe minor/patch bumps with it.

## Change

Split the `web` group by update-type:
- **web** — `minor` + `patch` (safe, keeps the existing name)
- **web-major** — `major` (reviewed individually)

Dependabot will now open two PRs instead of one.

## Follow-up

Once merged, comment `@dependabot recreate` on #32 → it regenerates as **20 minor/patch** (mergeable) + **6 majors** (tailwindcss, typescript, @vitejs/plugin-react, jsdom, @testing-library/jest-dom, @types/node) to review separately.