### PR TITLE
feat(judge): forward bazel_config from gavel.yaml to the bazel invocation

### DIFF
--- a/core/application/casefile/collectevidence/command.go
+++ b/core/application/casefile/collectevidence/command.go
@@ -17,6 +17,7 @@ type Command struct {
 	scopedTargets   []string
 	excludePatterns []string
 	toolSelection   map[string][]string
+	bazelConfigs    []string
 }
 
 type CommandOption func(*Command)
@@ -49,6 +50,12 @@ func WithScopedTargets(targets []string) CommandOption {
 func WithExcludePatterns(patterns []string) CommandOption {
 	return func(c *Command) {
 		c.excludePatterns = append([]string(nil), patterns...)
+	}
+}
+
+func WithBazelConfigs(configs []string) CommandOption {
+	return func(c *Command) {
+		c.bazelConfigs = append([]string(nil), configs...)
 	}
 }
 
@@ -87,3 +94,9 @@ func (c Command) ScopedTargets() []string   { return c.scopedTargets }
 func (c Command) ExcludePatterns() []string { return c.excludePatterns }
 
 func (c Command) ToolSelection() map[string][]string { return copyToolSelection(c.toolSelection) }
+
+func (c Command) BazelConfigs() []string {
+	copied := make([]string, len(c.bazelConfigs))
+	copy(copied, c.bazelConfigs)
+	return copied
+}

--- a/core/application/casefile/collectevidence/handler.go
+++ b/core/application/casefile/collectevidence/handler.go
@@ -179,14 +179,14 @@ func (h *Handler) collectFindings(ctx context.Context, cmd Command, targets []st
 	if h.findings == nil {
 		return nil, nil, "", nil, nil
 	}
-	return h.findings.CollectFindings(ctx, cmd.Workspace(), targets, cmd.ToolSelection())
+	return h.findings.CollectFindings(ctx, cmd.Workspace(), targets, cmd.ToolSelection(), cmd.BazelConfigs())
 }
 
 func (h *Handler) collectCoverage(ctx context.Context, cmd Command, targets []string, evidences *[]evidencedto.Evidence) (float64, []byte, error) {
 	if h.coverage == nil {
 		return 0, nil, nil
 	}
-	data, err := h.coverage.CollectCoverage(ctx, cmd.Workspace(), targets, cmd.Languages())
+	data, err := h.coverage.CollectCoverage(ctx, cmd.Workspace(), targets, cmd.Languages(), cmd.BazelConfigs())
 	if err != nil {
 		return 0, nil, fmt.Errorf("coverage: %w", err)
 	}
@@ -230,7 +230,7 @@ func (h *Handler) collectArchitecture(ctx context.Context, cmd Command, targets 
 	if h.architecture == nil {
 		return nil, 0, nil, classifyarch.Result{}, nil
 	}
-	archEv, archDocs, err := h.architecture.CollectViolations(ctx, cmd.Workspace(), targets, cmd.ToolSelection())
+	archEv, archDocs, err := h.architecture.CollectViolations(ctx, cmd.Workspace(), targets, cmd.ToolSelection(), cmd.BazelConfigs())
 	if err != nil {
 		return nil, 0, nil, classifyarch.Result{}, fmt.Errorf("architecture: %w", err)
 	}

--- a/core/application/casefile/collectevidence/handler_test.go
+++ b/core/application/casefile/collectevidence/handler_test.go
@@ -26,7 +26,7 @@ type fakeFindingsCollector struct {
 	err             error
 }
 
-func (f *fakeFindingsCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
+func (f *fakeFindingsCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string, _ []string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	return f.evidences, f.rawFiles, f.buildWarning, f.unanalyzedTools, f.err
 }
 
@@ -35,7 +35,7 @@ type fakeCoverageCollector struct {
 	err  error
 }
 
-func (f *fakeCoverageCollector) CollectCoverage(_ context.Context, _ string, _ []string, _ []string) ([]byte, error) {
+func (f *fakeCoverageCollector) CollectCoverage(_ context.Context, _ string, _ []string, _ []string, _ []string) ([]byte, error) {
 	return f.data, f.err
 }
 
@@ -45,7 +45,7 @@ type fakeArchCollector struct {
 	err      error
 }
 
-func (f *fakeArchCollector) CollectViolations(_ context.Context, _ string, _ []string, _ map[string][]string) (*evidencedto.Evidence, [][]byte, error) {
+func (f *fakeArchCollector) CollectViolations(_ context.Context, _ string, _ []string, _ map[string][]string, _ []string) (*evidencedto.Evidence, [][]byte, error) {
 	return f.evidence, f.docs, f.err
 }
 
@@ -59,13 +59,15 @@ func (f *fakeChangedLinesSource) ChangedLines(_ context.Context, _, _ string) (m
 }
 
 type capturingFindingsCollector struct {
-	capturedTargets []string
-	evidences       []evidencedto.Evidence
-	rawFiles        []collectevidence.RawFile
+	capturedTargets      []string
+	capturedBazelConfigs []string
+	evidences            []evidencedto.Evidence
+	rawFiles             []collectevidence.RawFile
 }
 
-func (c *capturingFindingsCollector) CollectFindings(_ context.Context, _ string, targets []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
+func (c *capturingFindingsCollector) CollectFindings(_ context.Context, _ string, targets []string, _ map[string][]string, bazelConfigs []string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	c.capturedTargets = targets
+	c.capturedBazelConfigs = bazelConfigs
 	return c.evidences, c.rawFiles, "", nil, nil
 }
 
@@ -290,6 +292,29 @@ func TestExecute_WithScopedTargets_PassesToCollectors(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, scoped, capturing.capturedTargets)
+}
+
+func TestExecute_WithBazelConfigs_PassesToCollectors(t *testing.T) {
+	capturing := &capturingFindingsCollector{}
+
+	sarifParser := sarif.NewParser()
+	lcovParser := lcov.NewParser()
+	handler := collectevidence.NewHandler(
+		capturing, &fakeCoverageCollector{}, &fakeArchCollector{},
+		ingestfind.NewHandler(map[string]ingestfind.Parser{"sarif": sarifParser}),
+		ingestcov.NewHandler(map[string]ingestcov.Parser{"lcov": lcovParser}),
+		classifyarch.NewHandler(), ingestncc.NewHandler(lcovParser),
+	)
+
+	cmd, err := collectevidence.NewCommand("/ws", "//core/...", "core", "main", []string{"go"}, true, false, nil,
+		collectevidence.WithBazelConfigs([]string{"remote", "ci"}),
+	)
+	require.NoError(t, err)
+
+	_, err = handler.Execute(context.Background(), cmd)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"remote", "ci"}, capturing.capturedBazelConfigs)
 }
 
 func TestExecute_WithChangedLinesSource_InvokesNCC(t *testing.T) {

--- a/core/application/casefile/collectevidence/ports.go
+++ b/core/application/casefile/collectevidence/ports.go
@@ -7,15 +7,15 @@ import (
 )
 
 type FindingsCollector interface {
-	CollectFindings(ctx context.Context, workspace string, targets []string, selection map[string][]string) ([]evidencedto.Evidence, []RawFile, string, []string, error)
+	CollectFindings(ctx context.Context, workspace string, targets []string, selection map[string][]string, bazelConfigs []string) ([]evidencedto.Evidence, []RawFile, string, []string, error)
 }
 
 type CoverageCollector interface {
-	CollectCoverage(ctx context.Context, workspace string, targets []string, languages []string) ([]byte, error)
+	CollectCoverage(ctx context.Context, workspace string, targets []string, languages []string, bazelConfigs []string) ([]byte, error)
 }
 
 type ArchitectureCollector interface {
-	CollectViolations(ctx context.Context, workspace string, targets []string, selection map[string][]string) (*evidencedto.Evidence, [][]byte, error)
+	CollectViolations(ctx context.Context, workspace string, targets []string, selection map[string][]string, bazelConfigs []string) (*evidencedto.Evidence, [][]byte, error)
 }
 
 type ChangedLinesSource interface {

--- a/core/application/gavelspace/loadgavelspace/result.go
+++ b/core/application/gavelspace/loadgavelspace/result.go
@@ -17,6 +17,7 @@ type WorkspaceView struct {
 	ServerURL      string
 	ServerToken    string
 	FindingsSource string
+	BazelConfigs   []string
 	Projects       []ProjectView
 }
 
@@ -31,6 +32,7 @@ type ProjectView struct {
 	GateRules       []GateRuleView
 	Baseline        BaselineView
 	ArchPolicy      *ArchPolicyView
+	BazelConfigs    []string
 }
 
 type GateRuleView struct {
@@ -65,6 +67,7 @@ func buildView(gavelspace gavelspacemodel.Gavelspace, projects []projectmodel.Pr
 		TenantID:       gavelspace.TenantID().String(),
 		GavelspaceName: gavelspace.ID().String(),
 		FindingsSource: gavelspace.FindingsSource(),
+		BazelConfigs:   gavelspace.BazelConfigs(),
 	}
 	if gavelspace.ServerConfig().IsConfigured() {
 		view.ServerURL = gavelspace.ServerConfig().URL()
@@ -114,6 +117,7 @@ func buildView(gavelspace gavelspacemodel.Gavelspace, projects []projectmodel.Pr
 			GateRules:       rules,
 			Baseline:        baselineView,
 			ArchPolicy:      archPolicyView,
+			BazelConfigs:    view.BazelConfigs,
 		})
 	}
 	return view

--- a/core/domain/gavelspace/model/gavelspace.go
+++ b/core/domain/gavelspace/model/gavelspace.go
@@ -15,6 +15,7 @@ type Gavelspace struct {
 	projects       []ProjectRef
 	serverConfig   ServerConfig
 	findingsSource string
+	bazelConfigs   []string
 	events         []event.DomainEvent
 }
 
@@ -49,6 +50,18 @@ func (g *Gavelspace) FindingsSource() string     { return g.findingsSource }
 
 func (g *Gavelspace) SetServerConfig(sc ServerConfig) { g.serverConfig = sc }
 func (g *Gavelspace) SetFindingsSource(source string) { g.findingsSource = source }
+
+func (g *Gavelspace) BazelConfigs() []string {
+	copied := make([]string, len(g.bazelConfigs))
+	copy(copied, g.bazelConfigs)
+	return copied
+}
+
+func (g *Gavelspace) SetBazelConfigs(configs []string) {
+	copied := make([]string, len(configs))
+	copy(copied, configs)
+	g.bazelConfigs = copied
+}
 
 func (g *Gavelspace) Projects() []ProjectRef {
 	copied := make([]ProjectRef, len(g.projects))

--- a/core/domain/gavelspace/model/gavelspace_enrichment_test.go
+++ b/core/domain/gavelspace/model/gavelspace_enrichment_test.go
@@ -33,6 +33,33 @@ func TestGavelspace_FindingsSource(t *testing.T) {
 	assert.Equal(t, "rules_lint", gspace.FindingsSource())
 }
 
+func TestGavelspace_BazelConfigs(t *testing.T) {
+	gspace, err := model.NewGavelspace(testTenant, "myrepo")
+	require.NoError(t, err)
+
+	assert.Empty(t, gspace.BazelConfigs())
+
+	gspace.SetBazelConfigs([]string{"remote", "ci"})
+
+	assert.Equal(t, []string{"remote", "ci"}, gspace.BazelConfigs())
+}
+
+func TestGavelspace_BazelConfigsDefensiveCopy(t *testing.T) {
+	gspace, err := model.NewGavelspace(testTenant, "myrepo")
+	require.NoError(t, err)
+
+	input := []string{"remote"}
+	gspace.SetBazelConfigs(input)
+	input[0] = "mutated"
+
+	assert.Equal(t, []string{"remote"}, gspace.BazelConfigs())
+
+	returned := gspace.BazelConfigs()
+	returned[0] = "mutated"
+
+	assert.Equal(t, []string{"remote"}, gspace.BazelConfigs())
+}
+
 func TestCoverageOptions(t *testing.T) {
 	opts := model.NewCoverageOptions("small,medium", "-docker", "//core[/:]")
 

--- a/core/infrastructure/gavelspace/gavelconfig/config_dto.go
+++ b/core/infrastructure/gavelspace/gavelconfig/config_dto.go
@@ -5,4 +5,5 @@ type configDTO struct {
 	Projects       []projectDTO `yaml:"projects"`
 	Server         serverDTO    `yaml:"server,omitempty"`
 	FindingsSource string       `yaml:"findings_source,omitempty"`
+	BazelConfig    []string     `yaml:"bazel_config,omitempty"`
 }

--- a/core/infrastructure/gavelspace/gavelconfig/parser.go
+++ b/core/infrastructure/gavelspace/gavelconfig/parser.go
@@ -83,8 +83,13 @@ func mapToDomain(dto configDTO) (WorkspaceConfig, error) {
 		return WorkspaceConfig{}, err
 	}
 
+	if err := validateBazelConfigs(dto.BazelConfig); err != nil {
+		return WorkspaceConfig{}, err
+	}
+
 	gavelspace.SetServerConfig(gavelspacemodel.NewServerConfig(dto.Server.URL, dto.Server.Token))
 	gavelspace.SetFindingsSource(dto.FindingsSource)
+	gavelspace.SetBazelConfigs(dto.BazelConfig)
 
 	return WorkspaceConfig{
 		gavelspace:      gavelspace,
@@ -92,6 +97,7 @@ func mapToDomain(dto configDTO) (WorkspaceConfig, error) {
 		coverageOptions: covOptions,
 		server:          ServerConfig{url: dto.Server.URL, token: dto.Server.Token},
 		findingsSource:  dto.FindingsSource,
+		bazelConfigs:    dto.BazelConfig,
 	}, nil
 }
 
@@ -315,4 +321,26 @@ func validateFindingsSource(source string) error {
 	}
 
 	return fmt.Errorf("findings_source: unknown value %q (valid: auto, gavel, rules_lint)", source)
+}
+
+func validateBazelConfigs(names []string) error {
+	for _, name := range names {
+		if err := validateBazelConfigName(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateBazelConfigName(name string) error {
+	if name == "" {
+		return fmt.Errorf("bazel_config: config name must not be empty")
+	}
+	if strings.ContainsAny(name, " \t\n=") {
+		return fmt.Errorf("bazel_config: invalid config name %q: must not contain whitespace or '='", name)
+	}
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf("bazel_config: invalid config name %q: must not start with '-'", name)
+	}
+	return nil
 }

--- a/core/infrastructure/gavelspace/gavelconfig/parser_test.go
+++ b/core/infrastructure/gavelspace/gavelconfig/parser_test.go
@@ -751,6 +751,66 @@ projects:
 	assert.Contains(t, err.Error(), "unknown_source")
 }
 
+func TestParseShouldAcceptBazelConfig(t *testing.T) {
+	data := []byte(`
+name: mono
+bazel_config: [remote]
+projects:
+  - name: svc
+    pattern: //svc/...
+`)
+
+	config, err := gavelconfig.Parse(data)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"remote"}, config.BazelConfigs())
+}
+
+func TestParseShouldAcceptMultipleBazelConfigs(t *testing.T) {
+	data := []byte(`
+name: mono
+bazel_config: [remote, ci]
+projects:
+  - name: svc
+    pattern: //svc/...
+`)
+
+	config, err := gavelconfig.Parse(data)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"remote", "ci"}, config.BazelConfigs())
+}
+
+func TestParseShouldDefaultBazelConfigToEmpty(t *testing.T) {
+	data := []byte(`
+name: mono
+projects:
+  - name: svc
+    pattern: //svc/...
+`)
+
+	config, err := gavelconfig.Parse(data)
+
+	require.NoError(t, err)
+	assert.Empty(t, config.BazelConfigs())
+}
+
+func TestParseShouldRejectInvalidBazelConfigName(t *testing.T) {
+	data := []byte(`
+name: mono
+bazel_config: ["-bad"]
+projects:
+  - name: svc
+    pattern: //svc/...
+`)
+
+	_, err := gavelconfig.Parse(data)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bazel_config")
+	assert.Contains(t, err.Error(), "-bad")
+}
+
 func TestParseFileNonexistentPathReturnsReadConfigError(t *testing.T) {
 	_, err := gavelconfig.ParseFile("/nonexistent/path/gavel.yaml")
 	require.Error(t, err)

--- a/core/infrastructure/gavelspace/gavelconfig/workspace_config.go
+++ b/core/infrastructure/gavelspace/gavelconfig/workspace_config.go
@@ -11,6 +11,7 @@ type WorkspaceConfig struct {
 	coverageOptions map[string]CoverageOptions
 	server          ServerConfig
 	findingsSource  string
+	bazelConfigs    []string
 }
 
 func (w WorkspaceConfig) Gavelspace() gavelspacemodel.Gavelspace { return w.gavelspace }
@@ -27,3 +28,9 @@ func (w WorkspaceConfig) CoverageOptionsForProject(name string) CoverageOptions 
 
 func (w WorkspaceConfig) Server() ServerConfig   { return w.server }
 func (w WorkspaceConfig) FindingsSource() string { return w.findingsSource }
+
+func (w WorkspaceConfig) BazelConfigs() []string {
+	copied := make([]string, len(w.bazelConfigs))
+	copy(copied, w.bazelConfigs)
+	return copied
+}

--- a/core/infrastructure/platform/bazel/collector/architecture.go
+++ b/core/infrastructure/platform/bazel/collector/architecture.go
@@ -19,7 +19,7 @@ func NewBazelArchitectureCollector(r AnalysisRunner) *BazelArchitectureCollector
 	return &BazelArchitectureCollector{runner: r}
 }
 
-func (c *BazelArchitectureCollector) CollectViolations(ctx context.Context, workspace string, targets []string, selection map[string][]string) (*evidencedto.Evidence, [][]byte, error) {
+func (c *BazelArchitectureCollector) CollectViolations(ctx context.Context, workspace string, targets []string, selection map[string][]string, bazelConfigs []string) (*evidencedto.Evidence, [][]byte, error) {
 	selected, err := catalog.SelectedAspects(selection)
 	if err != nil {
 		return nil, nil, err
@@ -35,9 +35,10 @@ func (c *BazelArchitectureCollector) CollectViolations(ctx context.Context, work
 	}
 
 	config := runner.AnalysisConfig{
-		Workspace: workspace,
-		Targets:   targets,
-		Aspects:   archAspects,
+		Workspace:    workspace,
+		Targets:      targets,
+		Aspects:      archAspects,
+		BazelConfigs: bazelConfigs,
 	}
 
 	result, err := c.runner.RunAnalysis(ctx, config)

--- a/core/infrastructure/platform/bazel/collector/architecture_test.go
+++ b/core/infrastructure/platform/bazel/collector/architecture_test.go
@@ -18,7 +18,7 @@ func TestBazelArchitectureCollector_NoAspects_ReturnsNil(t *testing.T) {
 	runner := &fakeAnalysisRunner{sarifFiles: map[string][][]byte{}}
 	c := collector.NewBazelArchitectureCollector(runner)
 
-	ev, docs, err := c.CollectViolations(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"archtest"}})
+	ev, docs, err := c.CollectViolations(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"archtest"}}, nil)
 
 	require.NoError(t, err)
 	assert.Nil(t, ev)
@@ -29,7 +29,7 @@ func TestBazelArchitectureCollector_NoArchAspectsForUnknownLanguage(t *testing.T
 	r := &fakeAnalysisRunner{sarifFiles: map[string][][]byte{}}
 	c := collector.NewBazelArchitectureCollector(r)
 
-	ev, docs, err := c.CollectViolations(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{})
+	ev, docs, err := c.CollectViolations(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{}, nil)
 
 	require.NoError(t, err)
 	assert.Nil(t, ev)
@@ -40,7 +40,7 @@ func TestBazelArchitectureCollector_RunnerError(t *testing.T) {
 	r := &fakeAnalysisRunner{err: fmt.Errorf("bazel failed")}
 	c := collector.NewBazelArchitectureCollector(r)
 
-	_, _, err := c.CollectViolations(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"archtest"}})
+	_, _, err := c.CollectViolations(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"archtest"}}, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "run archtest")
@@ -50,7 +50,7 @@ func TestBazelArchitectureCollector_InvalidSARIF(t *testing.T) {
 	r := &fakeAnalysisRunner{sarifFiles: map[string][][]byte{"go_archtest_submission_aspect": {[]byte("{invalid}")}}}
 	c := collector.NewBazelArchitectureCollector(r)
 
-	_, _, err := c.CollectViolations(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"archtest"}})
+	_, _, err := c.CollectViolations(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"archtest"}}, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse archtest SARIF")
@@ -61,7 +61,7 @@ func TestBazelArchitectureCollector_ParsesViolations(t *testing.T) {
 	runner := &fakeAnalysisRunner{sarifFiles: map[string][][]byte{"go_archtest_submission_aspect": {archSarif}}}
 	c := collector.NewBazelArchitectureCollector(runner)
 
-	ev, docs, err := c.CollectViolations(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"archtest"}})
+	ev, docs, err := c.CollectViolations(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"archtest"}}, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, ev)

--- a/core/infrastructure/platform/bazel/collector/composite/coverage.go
+++ b/core/infrastructure/platform/bazel/collector/composite/coverage.go
@@ -16,8 +16,8 @@ func NewCoverageCollector(primary, fallback collectevidence.CoverageCollector) *
 	return &CoverageCollector{primary: primary, fallback: fallback}
 }
 
-func (c *CoverageCollector) CollectCoverage(ctx context.Context, workspace string, targets []string, languages []string) ([]byte, error) {
-	data, err := c.primary.CollectCoverage(ctx, workspace, targets, languages)
+func (c *CoverageCollector) CollectCoverage(ctx context.Context, workspace string, targets []string, languages []string, bazelConfigs []string) ([]byte, error) {
+	data, err := c.primary.CollectCoverage(ctx, workspace, targets, languages, bazelConfigs)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (c *CoverageCollector) CollectCoverage(ctx context.Context, workspace strin
 		return data, nil
 	}
 
-	fallbackData, err := c.fallback.CollectCoverage(ctx, workspace, targets, languages)
+	fallbackData, err := c.fallback.CollectCoverage(ctx, workspace, targets, languages, bazelConfigs)
 	if err != nil {
 		return data, nil
 	}

--- a/core/infrastructure/platform/bazel/collector/composite/coverage_test.go
+++ b/core/infrastructure/platform/bazel/collector/composite/coverage_test.go
@@ -19,7 +19,7 @@ type fakeCoverageCollector struct {
 	err  error
 }
 
-func (f *fakeCoverageCollector) CollectCoverage(_ context.Context, _ string, _ []string, _ []string) ([]byte, error) {
+func (f *fakeCoverageCollector) CollectCoverage(_ context.Context, _ string, _ []string, _ []string, _ []string) ([]byte, error) {
 	return f.data, f.err
 }
 
@@ -30,7 +30,7 @@ func TestCompositePrimaryReturnsData(t *testing.T) {
 
 	collector := composite.NewCoverageCollector(primary, fallback)
 
-	data, err := collector.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"})
+	data, err := collector.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"}, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, lcov, data)
@@ -43,7 +43,7 @@ func TestCompositeFallbackWhenPrimaryEmpty(t *testing.T) {
 
 	collector := composite.NewCoverageCollector(primary, fallback)
 
-	data, err := collector.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"})
+	data, err := collector.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"}, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, vitestLCOV, data)
@@ -55,7 +55,7 @@ func TestCompositeNoFallbackWithoutTypeScript(t *testing.T) {
 
 	collector := composite.NewCoverageCollector(primary, fallback)
 
-	data, err := collector.CollectCoverage(context.Background(), "/ws", []string{"//core/..."}, []string{"go"})
+	data, err := collector.CollectCoverage(context.Background(), "/ws", []string{"//core/..."}, []string{"go"}, nil)
 
 	require.NoError(t, err)
 	assert.Nil(t, data)
@@ -67,7 +67,7 @@ func TestCompositePrimaryError(t *testing.T) {
 
 	coll := composite.NewCoverageCollector(primary, fallback)
 
-	_, err := coll.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"})
+	_, err := coll.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"}, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bazel failed")
@@ -78,7 +78,7 @@ func TestCompositeNilFallback(t *testing.T) {
 
 	coll := composite.NewCoverageCollector(primary, nil)
 
-	data, err := coll.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"})
+	data, err := coll.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"}, nil)
 
 	require.NoError(t, err)
 	assert.Nil(t, data)
@@ -91,7 +91,7 @@ func TestCompositeFallbackError_ReturnsPrimaryData(t *testing.T) {
 
 	coll := composite.NewCoverageCollector(primary, fallback)
 
-	data, err := coll.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"})
+	data, err := coll.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"}, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, emptyCov, data)
@@ -104,7 +104,7 @@ func TestCompositeFallbackReturnsNil_ReturnsPrimaryData(t *testing.T) {
 
 	coll := composite.NewCoverageCollector(primary, fallback)
 
-	data, err := coll.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"})
+	data, err := coll.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"}, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, emptyCov, data)
@@ -118,7 +118,7 @@ func TestCompositeFallbackOnZeroCoverage(t *testing.T) {
 
 	collector := composite.NewCoverageCollector(primary, fallback)
 
-	data, err := collector.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"})
+	data, err := collector.CollectCoverage(context.Background(), "/ws", []string{"//app/..."}, []string{"typescript"}, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, vitestLCOV, data)

--- a/core/infrastructure/platform/bazel/collector/coverage.go
+++ b/core/infrastructure/platform/bazel/collector/coverage.go
@@ -15,11 +15,12 @@ func NewBazelCoverageCollector(r AnalysisRunner) *BazelCoverageCollector {
 	return &BazelCoverageCollector{runner: r}
 }
 
-func (c *BazelCoverageCollector) CollectCoverage(ctx context.Context, workspace string, targets []string, _ []string) ([]byte, error) {
+func (c *BazelCoverageCollector) CollectCoverage(ctx context.Context, workspace string, targets []string, _ []string, bazelConfigs []string) ([]byte, error) {
 	config := runner.AnalysisConfig{
 		Workspace:       workspace,
 		Targets:         targets,
 		IncludeCoverage: true,
+		BazelConfigs:    bazelConfigs,
 	}
 
 	result, err := c.runner.RunAnalysis(ctx, config)

--- a/core/infrastructure/platform/bazel/collector/coverage_test.go
+++ b/core/infrastructure/platform/bazel/collector/coverage_test.go
@@ -19,7 +19,7 @@ func TestBazelCoverageCollector_ReturnsCoverageData(t *testing.T) {
 	runner := &fakeAnalysisRunner{coverageData: lcov}
 	c := collector.NewBazelCoverageCollector(runner)
 
-	data, err := c.CollectCoverage(context.Background(), t.TempDir(), []string{"//pkg:lib"}, nil)
+	data, err := c.CollectCoverage(context.Background(), t.TempDir(), []string{"//pkg:lib"}, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, lcov, data)
@@ -29,7 +29,7 @@ func TestBazelCoverageCollector_RunnerError(t *testing.T) {
 	r := &fakeAnalysisRunner{err: fmt.Errorf("bazel coverage failed")}
 	c := collector.NewBazelCoverageCollector(r)
 
-	_, err := c.CollectCoverage(context.Background(), t.TempDir(), []string{"//pkg:lib"}, nil)
+	_, err := c.CollectCoverage(context.Background(), t.TempDir(), []string{"//pkg:lib"}, nil, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "run coverage")
@@ -39,7 +39,7 @@ func TestBazelCoverageCollector_NilWhenNoCoverage(t *testing.T) {
 	runner := &fakeAnalysisRunner{}
 	c := collector.NewBazelCoverageCollector(runner)
 
-	data, err := c.CollectCoverage(context.Background(), t.TempDir(), []string{"//pkg:lib"}, nil)
+	data, err := c.CollectCoverage(context.Background(), t.TempDir(), []string{"//pkg:lib"}, nil, nil)
 
 	require.NoError(t, err)
 	assert.Nil(t, data)

--- a/core/infrastructure/platform/bazel/collector/findings.go
+++ b/core/infrastructure/platform/bazel/collector/findings.go
@@ -28,7 +28,7 @@ func NewBazelFindingsCollector(r AnalysisRunner, p FindingsParser) *BazelFinding
 	return &BazelFindingsCollector{runner: r, parser: p}
 }
 
-func (c *BazelFindingsCollector) CollectFindings(ctx context.Context, workspace string, targets []string, selection map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
+func (c *BazelFindingsCollector) CollectFindings(ctx context.Context, workspace string, targets []string, selection map[string][]string, bazelConfigs []string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	selected, err := catalog.SelectedAspects(selection)
 	if err != nil {
 		return nil, nil, "", nil, err
@@ -44,9 +44,10 @@ func (c *BazelFindingsCollector) CollectFindings(ctx context.Context, workspace 
 	}
 
 	config := runner.AnalysisConfig{
-		Workspace: workspace,
-		Targets:   targets,
-		Aspects:   lintAspects,
+		Workspace:    workspace,
+		Targets:      targets,
+		Aspects:      lintAspects,
+		BazelConfigs: bazelConfigs,
 	}
 
 	result, err := c.runner.RunAnalysis(ctx, config)

--- a/core/infrastructure/platform/bazel/collector/findings_test.go
+++ b/core/infrastructure/platform/bazel/collector/findings_test.go
@@ -19,7 +19,7 @@ func TestBazelFindingsCollector_NoReports_ReturnsEmpty(t *testing.T) {
 	parser := &fakeFindingsParser{}
 	c := collector.NewBazelFindingsCollector(runner, parser)
 
-	evidences, rawFiles, buildWarning, unanalyzed, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	evidences, rawFiles, buildWarning, unanalyzed, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}}, nil)
 
 	require.NoError(t, err)
 	assert.Empty(t, evidences)
@@ -35,7 +35,7 @@ func TestBazelFindingsCollector_ParsesReports(t *testing.T) {
 	parser := &fakeFindingsParser{returnEmpty: true}
 	c := collector.NewBazelFindingsCollector(runner, parser)
 
-	evidences, rawFiles, buildWarning, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	evidences, rawFiles, buildWarning, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}}, nil)
 
 	require.NoError(t, err)
 	assert.Len(t, evidences, 1)
@@ -49,7 +49,7 @@ func TestBazelFindingsCollector_NoAspectsForEmptySelection(t *testing.T) {
 	parser := &fakeFindingsParser{}
 	c := collector.NewBazelFindingsCollector(r, parser)
 
-	evidences, rawFiles, buildWarning, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{})
+	evidences, rawFiles, buildWarning, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{}, nil)
 
 	require.NoError(t, err)
 	assert.Nil(t, evidences)
@@ -62,7 +62,7 @@ func TestBazelFindingsCollector_RunnerError(t *testing.T) {
 	parser := &fakeFindingsParser{}
 	c := collector.NewBazelFindingsCollector(r, parser)
 
-	_, _, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	_, _, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}}, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "run analysis")
@@ -74,7 +74,7 @@ func TestBazelFindingsCollector_ParserError(t *testing.T) {
 	parser := &fakeFindingsParser{err: fmt.Errorf("parse failed")}
 	c := collector.NewBazelFindingsCollector(r, parser)
 
-	_, _, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	_, _, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}}, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse failed")
@@ -85,7 +85,7 @@ func TestBazelFindingsCollector_EmptySARIFData(t *testing.T) {
 	parser := &fakeFindingsParser{}
 	c := collector.NewBazelFindingsCollector(r, parser)
 
-	_, _, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	_, _, _, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}}, nil)
 
 	require.Error(t, err)
 }
@@ -99,7 +99,7 @@ func TestBazelFindingsCollector_PropagatesBuildWarning(t *testing.T) {
 	parser := &fakeFindingsParser{returnEmpty: true}
 	c := collector.NewBazelFindingsCollector(runner, parser)
 
-	evidences, rawFiles, buildWarning, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}})
+	evidences, rawFiles, buildWarning, _, err := c.CollectFindings(context.Background(), t.TempDir(), []string{"//pkg:lib"}, map[string][]string{"go": {"golangci-lint"}}, nil)
 
 	require.NoError(t, err)
 	assert.Len(t, evidences, 1)

--- a/core/infrastructure/platform/bazel/collector/vitest.go
+++ b/core/infrastructure/platform/bazel/collector/vitest.go
@@ -15,7 +15,7 @@ func NewVitestCoverageCollector(log *slog.Logger) *VitestCoverageCollector {
 	return &VitestCoverageCollector{log: log}
 }
 
-func (c *VitestCoverageCollector) CollectCoverage(ctx context.Context, workspace string, targets []string, _ []string) ([]byte, error) {
+func (c *VitestCoverageCollector) CollectCoverage(ctx context.Context, workspace string, targets []string, _ []string, _ []string) ([]byte, error) {
 	if len(targets) == 0 {
 		return nil, nil
 	}

--- a/core/infrastructure/platform/bazel/collector/vitest_test.go
+++ b/core/infrastructure/platform/bazel/collector/vitest_test.go
@@ -14,7 +14,7 @@ import (
 func TestVitestCollectorEmptyTargets(t *testing.T) {
 	c := collector.NewVitestCoverageCollector(slog.Default())
 
-	data, err := c.CollectCoverage(context.Background(), t.TempDir(), nil, nil)
+	data, err := c.CollectCoverage(context.Background(), t.TempDir(), nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Nil(t, data)

--- a/core/infrastructure/platform/bazel/runner/analysis.go
+++ b/core/infrastructure/platform/bazel/runner/analysis.go
@@ -21,6 +21,7 @@ type AnalysisConfig struct {
 	IncludeCoverage bool
 	TestSizeFilters string
 	TestTagFilters  string
+	BazelConfigs    []string
 }
 
 type AnalysisResult struct {
@@ -35,7 +36,10 @@ func RunAnalysis(ctx context.Context, config AnalysisConfig) (*AnalysisResult, e
 }
 
 func runAnalysis(ctx context.Context, cmd CommandRunner, config AnalysisConfig) (*AnalysisResult, error) {
-	args := buildBazelArgs(config)
+	args, err := buildBazelArgs(config)
+	if err != nil {
+		return nil, err
+	}
 
 	stdout, stderr, runErr := cmd.Run(ctx, config.Workspace, "bazel", args...)
 	output := string(stdout) + string(stderr)
@@ -71,13 +75,20 @@ func runAnalysis(ctx context.Context, cmd CommandRunner, config AnalysisConfig) 
 	return result, nil
 }
 
-func buildBazelArgs(config AnalysisConfig) []string {
+func buildBazelArgs(config AnalysisConfig) ([]string, error) {
 	var args []string
 	if config.IncludeCoverage {
 		args = append(args, "coverage")
 	} else {
 		args = append(args, "build")
 	}
+
+	configArgs, err := bazelConfigArgs(config.BazelConfigs)
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, configArgs...)
+
 	args = append(args,
 		"--aspects="+catalog.AspectPaths(config.Aspects),
 		"--output_groups=gavel_submissions",
@@ -109,7 +120,31 @@ func buildBazelArgs(config AnalysisConfig) []string {
 
 	args = append(args, "--")
 	args = append(args, config.Targets...)
-	return args
+	return args, nil
+}
+
+func bazelConfigArgs(names []string) ([]string, error) {
+	args := make([]string, 0, len(names))
+	for _, name := range names {
+		if err := validateBazelConfigName(name); err != nil {
+			return nil, err
+		}
+		args = append(args, "--config="+name)
+	}
+	return args, nil
+}
+
+func validateBazelConfigName(name string) error {
+	if name == "" {
+		return fmt.Errorf("bazel_config: config name must not be empty")
+	}
+	if strings.ContainsAny(name, " \t\n=") {
+		return fmt.Errorf("bazel_config: invalid config name %q: must not contain whitespace or '='", name)
+	}
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf("bazel_config: invalid config name %q: must not start with '-'", name)
+	}
+	return nil
 }
 
 func scopeBinDir(binDir string, targets []string) string {

--- a/core/infrastructure/platform/bazel/runner/analysis_test.go
+++ b/core/infrastructure/platform/bazel/runner/analysis_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,7 +49,8 @@ func TestBuildBazelArgs_TargetsAfterOptionsMarker(t *testing.T) {
 		Aspects: []catalog.Aspect{{Path: "p"}},
 	}
 
-	args := buildBazelArgs(config)
+	args, err := buildBazelArgs(config)
+	require.NoError(t, err)
 
 	marker := slices.Index(args, "--")
 	require.GreaterOrEqual(t, marker, 0, "args must contain the -- options-end marker")
@@ -70,7 +72,8 @@ func TestBuildBazelArgs_IncludesAspectBuildFlagsBeforeMarker(t *testing.T) {
 		},
 	}
 
-	args := buildBazelArgs(config)
+	args, err := buildBazelArgs(config)
+	require.NoError(t, err)
 
 	idx := slices.Index(args, "--@rules_go//go/config:export_stdlib=True")
 	require.GreaterOrEqual(t, idx, 0, "golangci's build flag must reach the combined invocation")
@@ -87,7 +90,8 @@ func TestBuildBazelArgs_DeduplicatesSharedBuildFlags(t *testing.T) {
 		},
 	}
 
-	args := buildBazelArgs(config)
+	args, err := buildBazelArgs(config)
+	require.NoError(t, err)
 
 	count := 0
 	for _, arg := range args {
@@ -105,7 +109,8 @@ func TestBuildBazelArgs_CoverageMode(t *testing.T) {
 		IncludeCoverage: true,
 	}
 
-	args := buildBazelArgs(config)
+	args, err := buildBazelArgs(config)
+	require.NoError(t, err)
 
 	assert.Equal(t, "coverage", args[0])
 	assert.Contains(t, args, "--test_size_filters=small,medium")
@@ -116,10 +121,12 @@ func TestBuildBazelArgs_CoverageMode(t *testing.T) {
 }
 
 func TestBuildBazelArgs_CoverageBoundsMemory(t *testing.T) {
-	cov := buildBazelArgs(AnalysisConfig{Targets: []string{"//..."}, IncludeCoverage: true})
+	cov, err := buildBazelArgs(AnalysisConfig{Targets: []string{"//..."}, IncludeCoverage: true})
+	require.NoError(t, err)
 	assert.Contains(t, cov, "--local_resources=memory=HOST_RAM*0.67")
 
-	build := buildBazelArgs(AnalysisConfig{Targets: []string{"//..."}, IncludeCoverage: false})
+	build, err := buildBazelArgs(AnalysisConfig{Targets: []string{"//..."}, IncludeCoverage: false})
+	require.NoError(t, err)
 	for _, a := range build {
 		assert.NotContains(t, a, "local_resources")
 	}
@@ -132,7 +139,8 @@ func TestBuildBazelArgs_BuildMode(t *testing.T) {
 		IncludeCoverage: false,
 	}
 
-	args := buildBazelArgs(config)
+	args, err := buildBazelArgs(config)
+	require.NoError(t, err)
 
 	assert.Equal(t, "build", args[0])
 	for _, a := range args {
@@ -148,7 +156,8 @@ func TestBuildBazelArgs_DefaultTestSizeFilters(t *testing.T) {
 		IncludeCoverage: true,
 	}
 
-	args := buildBazelArgs(config)
+	args, err := buildBazelArgs(config)
+	require.NoError(t, err)
 
 	assert.Contains(t, args, "--test_size_filters=small,medium")
 }
@@ -161,7 +170,8 @@ func TestBuildBazelArgs_CustomTestSizeFilters(t *testing.T) {
 		TestSizeFilters: "small",
 	}
 
-	args := buildBazelArgs(config)
+	args, err := buildBazelArgs(config)
+	require.NoError(t, err)
 
 	assert.Contains(t, args, "--test_size_filters=small")
 	assert.NotContains(t, args, "--test_size_filters=small,medium")
@@ -174,9 +184,69 @@ func TestBuildBazelArgs_TestTagFilters(t *testing.T) {
 		TestTagFilters: "-integration,-manual",
 	}
 
-	args := buildBazelArgs(config)
+	args, err := buildBazelArgs(config)
+	require.NoError(t, err)
 
 	assert.Contains(t, args, "--test_tag_filters=-integration,-manual")
+}
+
+func TestBuildBazelArgs_BazelConfigsAfterVerbBeforeGavelFlags(t *testing.T) {
+	config := AnalysisConfig{
+		Targets:      []string{"//..."},
+		Aspects:      []catalog.Aspect{{Path: "p"}},
+		BazelConfigs: []string{"remote", "ci"},
+	}
+
+	args, err := buildBazelArgs(config)
+
+	require.NoError(t, err)
+	verbIdx := slices.Index(args, "build")
+	require.GreaterOrEqual(t, verbIdx, 0, "args must start with the bazel verb")
+
+	remoteIdx := slices.Index(args, "--config=remote")
+	ciIdx := slices.Index(args, "--config=ci")
+	require.GreaterOrEqual(t, remoteIdx, 0, "expected --config=remote in args")
+	require.GreaterOrEqual(t, ciIdx, 0, "expected --config=ci in args")
+	assert.Greater(t, remoteIdx, verbIdx, "--config=remote must come after the bazel verb")
+	assert.Greater(t, ciIdx, verbIdx, "--config=ci must come after the bazel verb")
+
+	aspectsIdx := slices.IndexFunc(args, func(a string) bool { return strings.HasPrefix(a, "--aspects=") })
+	require.GreaterOrEqual(t, aspectsIdx, 0)
+	assert.Less(t, remoteIdx, aspectsIdx, "--config flags must come before gavel's own --aspects flag")
+	assert.Less(t, ciIdx, aspectsIdx, "--config flags must come before gavel's own --aspects flag")
+
+	outputGroupsIdx := slices.Index(args, "--output_groups=gavel_submissions")
+	keepGoingIdx := slices.Index(args, "--keep_going")
+	assert.Less(t, remoteIdx, outputGroupsIdx)
+	assert.Less(t, remoteIdx, keepGoingIdx)
+
+	markerIdx := slices.Index(args, "--")
+	require.GreaterOrEqual(t, markerIdx, 0)
+	assert.Less(t, aspectsIdx, markerIdx, "-- separator and targets must stay at the very end")
+	assert.Greater(t, slices.Index(args, "//..."), markerIdx)
+}
+
+func TestBuildBazelArgs_RejectsInvalidBazelConfigName(t *testing.T) {
+	tests := map[string]string{
+		"empty":            "",
+		"contains space":   "has space",
+		"contains equals":  "has=equals",
+		"starts with dash": "-startsdash",
+	}
+
+	for name, badValue := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := AnalysisConfig{
+				Targets:      []string{"//..."},
+				BazelConfigs: []string{badValue},
+			}
+
+			_, err := buildBazelArgs(config)
+
+			require.Error(t, err, "expected an error for bazel_config value %q", badValue)
+			assert.Contains(t, err.Error(), "bazel_config")
+		})
+	}
 }
 
 func TestBuildBazelArgs_MultipleAspects(t *testing.T) {
@@ -188,7 +258,8 @@ func TestBuildBazelArgs_MultipleAspects(t *testing.T) {
 		},
 	}
 
-	args := buildBazelArgs(config)
+	args, err := buildBazelArgs(config)
+	require.NoError(t, err)
 
 	found := false
 	for _, a := range args {

--- a/core/userinterface/cli/judge/judge.go
+++ b/core/userinterface/cli/judge/judge.go
@@ -396,6 +396,9 @@ func runProject(
 	if len(project.ToolSelection) > 0 {
 		cmdOpts = append(cmdOpts, collectevidence.WithToolSelection(project.ToolSelection))
 	}
+	if len(project.BazelConfigs) > 0 {
+		cmdOpts = append(cmdOpts, collectevidence.WithBazelConfigs(project.BazelConfigs))
+	}
 
 	collectCmd, err := collectevidence.NewCommand(workspace, project.TargetPattern, project.Name, project.DefaultBranch, project.Languages, opts.Quick, opts.Absolute, project.Baseline.ArchIDs, cmdOpts...)
 	if err != nil {

--- a/core/userinterface/cli/judge/judge_test.go
+++ b/core/userinterface/cli/judge/judge_test.go
@@ -293,7 +293,7 @@ func (f fakeFinder) LoadFromConfig(_ string) (gavelspacemodel.Gavelspace, []proj
 
 type stubFindingsCollector struct{}
 
-func (s stubFindingsCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
+func (s stubFindingsCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string, _ []string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	return []evidencedto.Evidence{{
 		Subtype:     "code_quality",
 		Source:      "empty.sarif",
@@ -729,7 +729,7 @@ type findingsCollectorWithData struct {
 	parser   *ingestfind.Handler
 }
 
-func (f *findingsCollectorWithData) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
+func (f *findingsCollectorWithData) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string, _ []string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	cmd, err := ingestfind.NewCommand([]byte(`{"runs":[]}`), "sarif", "test.sarif", "code_quality")
 	if err != nil {
 		return nil, nil, "", nil, err
@@ -915,7 +915,7 @@ type failingCollector struct {
 	err error
 }
 
-func (f *failingCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
+func (f *failingCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string, _ []string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	return nil, nil, "", nil, f.err
 }
 
@@ -946,7 +946,7 @@ func TestRun_CollectEvidenceError(t *testing.T) {
 
 type buildWarningCollector struct{}
 
-func (b *buildWarningCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
+func (b *buildWarningCollector) CollectFindings(_ context.Context, _ string, _ []string, _ map[string][]string, _ []string) ([]evidencedto.Evidence, []collectevidence.RawFile, string, []string, error) {
 	return []evidencedto.Evidence{{
 		Subtype:     "code_quality",
 		Source:      "empty.sarif",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ Defines the workspace name, projects, quality gate rules, and server connection.
 
 ```yaml
 name: <string>                              # workspace name (required)
+bazel_config: [<string>]                    # bazel --config(s) to activate for analysis (optional)
 
 projects:                                    # list of projects (required, at least one)
   - name: <string>                           # project name (required)
@@ -61,6 +62,13 @@ server:                                      # server connection (optional)
 
 **`name`** (string, required)
 Workspace name. Used for display and identification.
+
+**`bazel_config`** (list of strings, optional)
+Names of `--config` blocks (from your `.bazelrc`) to activate on the `bazel`
+invocation gavel runs — each entry `N` adds `--config=N`. Point gavel's analysis
+at your remote cache or RBE with `bazel_config: [remote]`, without gavel
+accepting arbitrary bazel flags: only named configs pass, and gavel's own flags
+always take precedence. Absent means no `--config` is added.
 
 **`projects`** (list, required)
 One or more projects to analyze. Each project maps to a set of Bazel targets


### PR DESCRIPTION
## What

Adds a workspace-level `bazel_config` list to `gavel.yaml`. Each entry `N` is forwarded as `--config=N` to the `bazel build/coverage` gavel runs for analysis.

```yaml
bazel_config: [remote]   # → bazel build --config=remote --aspects=… -- //...
```

## Why

You couldn't point gavel's internal bazel call at your remote cache / RBE — gavel forwarded no bazel config, so its `bazel` invocation ran without your `--config=remote` and rebuilt host tools locally. Raised as feedback: *"I can't pass any bazel config argument to gavel."*

## Design

- `--config=N` inserted **after the verb, before gavel's own flags** (`--aspects`, `--output_groups`, `--keep_going`) so gavel's flags always win; `--` + targets stay last.
- Only **named configs** pass (validated: reject empty / whitespace / `=` / leading `-`) — never arbitrary flags, so the invocation stays controlled.
- Threaded gavelconfig → gavelspace → collectevidence → the 3 bazel collectors → `AnalysisConfig` (mirrors the `ToolSelection` call-time mechanism; collectors are built at startup before `gavel.yaml` is parsed, so constructor injection can't reach them).

## Verified

- TDD (failing test first) for arg position, name validation, and config parsing.
- **End-to-end against a local NativeLink RBE:** with `bazel_config: [remote]` gavel's bazel connects to the remote cache (client connections 1 → 37, `GetCapabilities{instance_name: "main"}`); without it, no remote traffic.

## Note on size

Larger than a one-liner (25 files): delivering a workspace-level value to the collectors required widening 3 collector interfaces — the existing config paths dead-end before the collectors, which are built at startup. Followed the working `ToolSelection` pattern.